### PR TITLE
Bug fix for function updateLob: array to string conversion error.

### DIFF
--- a/src/yajra/Oci8/Query/OracleBuilder.php
+++ b/src/yajra/Oci8/Query/OracleBuilder.php
@@ -32,7 +32,7 @@ class OracleBuilder extends Builder {
 	 */
 	public function updateLob(array $values, array $binaries, $sequence = null)
 	{
-		$bindings = array_values(array_merge($values, $this->bindings));
+		$bindings = array_values(array_merge($values, $this->getBindings()));
 
 		$sql = $this->grammar->compileUpdateLob($this, $values, $binaries, $sequence);
 


### PR DESCRIPTION
I was trying to execute the following code:

``` php
public function testUpdateBlob($id)
{
        $filename = 'files/file.xlsx';
        $handle = fopen($filename, 'rb');

        $id = DB::table($this->_model->getTable())->whereId($id)->updateLob(
                array('name'=>'test'),
                array('blob' => fread($handle, filesize($filename)))
        );    
        fclose($handle);
}
```

and the error was: ErrorException: Array to string conversion.
Changing it to the correct getter instead of using the property directly resolved the problem.
