### PR TITLE
Support to set current_schema

### DIFF
--- a/src/yajra/Oci8/Connectors/OracleConnector.php
+++ b/src/yajra/Oci8/Connectors/OracleConnector.php
@@ -55,6 +55,13 @@ class OracleConnector extends Connector implements ConnectorInterface
 
         $connection = $this->createConnection($tns, $config, $options);
 
+        // Like Postgres, Oracle allows the concept of "schema"
+        if (isset($config['schema']))
+        {
+            $schema = $config['schema'];
+            $connection->prepare("ALTER SESSION SET CURRENT_SCHEMA = {$schema}")->execute();
+        }
+
         return $connection;
     }
 


### PR DESCRIPTION
Oracle allows the concept of "schema". To avoid using the schema name in the attribute $table (inside the model), just set the 'schema' in the connection parameters (database.php).
