### PR TITLE
ORA-01795 workaround

### DIFF
--- a/src/yajra/Oci8/Connectors/OracleConnector.php
+++ b/src/yajra/Oci8/Connectors/OracleConnector.php
@@ -83,7 +83,6 @@ class OracleConnector extends Connector implements ConnectorInterface
             $config['host'] = $config['hostname'];
 
         // check tns
-
         if ( empty($config['tns']) ) {
             // Create a description to locate the database to connect to
             $config['tns'] = "(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = {$config['host']})(PORT = {$config['port']})) (CONNECT_DATA =(SERVICE_NAME = {$config['database']})))";
@@ -93,7 +92,6 @@ class OracleConnector extends Connector implements ConnectorInterface
             } else {
                 $service_param = 'SERVICE_NAME = '.$config['service_name'];
             }
-
 
             $config['tns'] = "(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = {$config['host']})(PORT = {$config['port']})) (CONNECT_DATA =($service_param)))";
         }


### PR DESCRIPTION
This will require

```
use yajra\Oci8\Eloquent\OracleEloquent as Eloquent;
```

Would be good to extend Illuminate\Database\Query\Builder with this fix without having to use **yajra\Oci8\Eloquent\OracleEloquent** every time?
