### PR TITLE
Fix 64-bit PHP bug with INOUT bindParam call

### DIFF
--- a/src/yajra/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/yajra/Oci8/Query/Processors/OracleProcessor.php
@@ -33,7 +33,7 @@ class OracleProcessor extends Processor {
 		$counter = $this->bindValuesAndReturnCounter($values, $counter);
 
 		// bind output param for the returning clause
-		$this->statement->bindParam($counter, $id, PDO::PARAM_INT);
+		$this->statement->bindParam($counter, $id, PDO::PARAM_INT|PDO::PARAM_INPUT_OUTPUT, 8);
 
 		// execute statement
 		$this->statement->execute();

--- a/src/yajra/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/yajra/Oci8/Query/Processors/OracleProcessor.php
@@ -33,7 +33,7 @@ class OracleProcessor extends Processor {
 		$counter = $this->bindValuesAndReturnCounter($values, $counter);
 
 		// bind output param for the returning clause
-		$this->statement->bindParam($counter, $id, PDO::PARAM_INT|PDO::PARAM_INPUT_OUTPUT, 8);
+		$this->statement->bindParam($counter, $id, PDO::PARAM_INT|PDO::PARAM_INPUT_OUTPUT, 10);
 
 		// execute statement
 		$this->statement->execute();


### PR DESCRIPTION
When run on a 64-bit PHP installation, bindParam must be explicitly typed as INOUT with a length to get the correct integer casting