### PR TITLE
Wrap reserved words when commenting on table or columns

### DIFF
--- a/src/Oci8/Schema/Comment.php
+++ b/src/Oci8/Schema/Comment.php
@@ -50,10 +50,7 @@ class Comment extends Grammar
         $table = $this->wrapValue($blueprint->getTable());
 
         if ($blueprint->comment != null) {
-            $this->connection->statement(sprintf(
-                'comment on table %s is \'%s\'', $table,
-                $blueprint->comment
-            ));
+            $this->connection->statement("comment on table {$table} is '{$blueprint->comment}'");
         }
     }
 
@@ -84,7 +81,7 @@ class Comment extends Grammar
 
         $column = $this->wrapValue($column);
 
-        $this->connection->statement(sprintf('comment on column %s.%s is \'%s\'', $table, $column, $comment));
+        $this->connection->statement("comment on column {$table}.{$column} is '{$comment}'");
     }
 
     /**

--- a/src/Oci8/Schema/Comment.php
+++ b/src/Oci8/Schema/Comment.php
@@ -3,9 +3,13 @@
 namespace Yajra\Oci8\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Grammars\Grammar;
+use Yajra\Oci8\OracleReservedWords;
 
-class Comment
+class Comment extends Grammar
 {
+    use OracleReservedWords;
+
     /**
      * @var \Illuminate\Database\Connection
      */
@@ -43,9 +47,11 @@ class Comment
      */
     private function commentTable(OracleBlueprint $blueprint)
     {
+        $table = $this->wrapValue($blueprint->getTable());
+
         if ($blueprint->comment != null) {
             $this->connection->statement(sprintf(
-                'comment on table %s is \'%s\'', $blueprint->getTable(),
+                'comment on table %s is \'%s\'', $table,
                 $blueprint->comment
             ));
         }
@@ -74,6 +80,10 @@ class Comment
      */
     private function commentColumn($table, $column, $comment)
     {
+        $table = $this->wrapValue($table);
+
+        $column = $this->wrapValue($column);
+
         $this->connection->statement(sprintf('comment on column %s.%s is \'%s\'', $table, $column, $comment));
     }
 
@@ -87,5 +97,16 @@ class Comment
         foreach ($blueprint->commentColumns as $column => $comment) {
             $this->commentColumn($blueprint->getTable(), $column, $comment);
         }
+    }
+
+    /**
+     * Wrap reserved words.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function wrapValue($value)
+    {
+        return $this->isReserved($value) ? parent::wrapValue($value) : $value;
     }
 }


### PR DESCRIPTION
Any Oracle reserved words need to be wrapped before running comment statements.

For example, the following code on the User table
```php
$table->string('password', 60)->comment('User password');
```

will now generate
```plsql
comment on column user."password" is 'User password'
```

Without this, migrating a Laravel default application, which creates an User table with a Password column, will fail if the developer add some comment on it.