### PR TITLE
Drop sequence if table is dropped through Blueprint

### DIFF
--- a/src/Oci8/Schema/OracleBuilder.php
+++ b/src/Oci8/Schema/OracleBuilder.php
@@ -64,6 +64,14 @@ class OracleBuilder extends Builder
 
         $callback($blueprint);
 
+        foreach($blueprint->getCommands() as $command)
+        {
+            if ($command->get('name') == 'drop')
+            {
+                $this->helper->dropAutoIncrementObjects($table);
+            }
+        }
+
         $this->build($blueprint);
 
         $this->comment->setComments($blueprint);


### PR DESCRIPTION
The following code will now drop the associated sequence:
```php
Schema::table('name', function (Blueprint $table) {
    $table->drop();
});
```

- Fixes #106