### PR TITLE
Fork and solve error oracle when you execute getColumnListing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.phar
 composer.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 composer.phar
 composer.lock
-.idea

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -125,14 +125,15 @@ class OracleGrammar extends Grammar
         return "select * from user_tables where upper(table_name) = upper(?)";
     }
 
+
     /**
      * Compile the query to determine the list of columns.
      *
      * @return string
      */
-    public function compileColumnExists()
+    public function compileColumnExists($table="?")
     {
-        return "select column_name from user_tab_columns where table_name = upper(?) and column_name = upper(?)";
+        return "select column_name from user_tab_columns where table_name = upper('".$table."') and column_name = upper('".$table."')";
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -131,9 +131,9 @@ class OracleGrammar extends Grammar
      *
      * @return string
      */
-    public function compileColumnExists($table="?")
+    public function compileColumnExists($table)
     {
-        return "select column_name from user_tab_columns where table_name = upper('".$table."') and column_name = upper('".$table."')";
+        return "select column_name from user_tab_columns where table_name = upper('".$table."')";
     }
 
     /**

--- a/tests/Oci8SchemaGrammarTest.php
+++ b/tests/Oci8SchemaGrammarTest.php
@@ -271,8 +271,8 @@ class Oci8SchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testCompileColumnExistsMethod()
     {
         $grammar  = $this->getGrammar();
-        $expected = 'select column_name from user_tab_columns where table_name = upper(?) and column_name = upper(?)';
-        $sql      = $grammar->compileColumnExists();
+        $expected = 'select column_name from user_tab_columns where table_name = upper(\'test_table\')';
+        $sql      = $grammar->compileColumnExists("test_table");
         $this->assertEquals($expected, $sql);
     }
 


### PR DESCRIPTION
When you want to get the columns name of table with laravel you have to do it like this :

```
 \Schema::getColumnListing($this->model->getTable());

 ```

When we do that you have this error

```
Error Code : 1008
Error Message : ORA-01008: not all variables bound
Position : 0
Statement : select column_name from user_tab_columns where table_name = upper(:p0) and column_name = upper(:p1)
Bindings : []
(SQL: select column_name from user_tab_columns where table_name = upper(?) and column_name = upper(?))
```

This fix solve this error