### PR TITLE
Fix new instance Oci8Connection with config on last parameter.

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -40,7 +40,7 @@ class Oci8ServiceProvider extends ServiceProvider
         $this->app['db']->extend('oracle', function ($config) {
             $connector  = new Connector();
             $connection = $connector->connect($config);
-            $db         = new Oci8Connection($connection, $config["database"], $config["prefix"]);
+            $db         = new Oci8Connection($connection, $config["database"], $config["prefix"],$config);
 
             // set oracle session variables
             $sessionVars = [


### PR DESCRIPTION
When you want use

```php
   DB::connection()->getDriverName() == 'oracle'
   ```
   That return null because $config is not give to Oci8Connection. When you give them you can acces to thoses informations. To be complient with the other engine I need it.