### PR TITLE
Add oracle prefix schema

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -222,8 +222,9 @@ class Oci8Connection extends Connection
      */
     public function withTablePrefix(Grammar $grammar)
     {
-        return parent::withTablePrefix($grammar);
+        return $this->withSchemaPrefix(parent::withTablePrefix($grammar));
     }
+
 
     /**
      * Get the default schema grammar instance.
@@ -243,5 +244,25 @@ class Oci8Connection extends Connection
     protected function getDefaultPostProcessor()
     {
         return new Processor;
+    }
+
+
+    /**
+     * Set the table prefix and return the grammar.
+     *
+     * @param \Illuminate\Database\Grammar $grammar
+     * @return \Illuminate\Database\Grammar
+     */
+    public function withSchemaPrefix(Grammar $grammar)
+    {
+
+        $grammar->setSchemaPrefix($this->getConfigSchemaPrefix());
+
+        return $grammar;
+    }
+
+    protected function getConfigSchemaPrefix()
+    {
+        return isset($this->config['prefix_schema'])?$this->config['prefix_schema']:'';
     }
 }

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -18,6 +18,12 @@ class OracleGrammar extends Grammar
      */
     protected $wrapper = '%s';
 
+
+    /**
+     * @var string
+     */
+    protected $schema_prefix = '';
+
     /**
      * Compile an exists statement into SQL.
      *
@@ -386,5 +392,50 @@ class OracleGrammar extends Grammar
         }
 
         return $value !== '*' ? sprintf($this->wrapper, $value) : $value;
+    }
+
+
+    /**
+     * Compile the "from" portion of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  string $table
+     * @return string
+     */
+    protected function compileFrom(Builder $query, $table)
+    {
+
+        $query = $this->wrapTable($table);
+
+        if ($this->isSubQuery($query)) {
+            return 'from ' . $this->wrapTable($table);
+        }
+
+        return 'from ' . $this->getSchemaPrefix() . $this->wrapTable($table);
+    }
+
+
+    /**
+     * Set the shema prefix
+     *
+     * @param string $prefix
+     */
+    public function setSchemaPrefix($prefix)
+    {
+        $this->schema_prefix = $prefix;
+    }
+
+    /**
+     * Return the schema prefix
+     * @return string
+     */
+    public function getSchemaPrefix()
+    {
+        return !empty($this->schema_prefix) ? $this->schema_prefix . '.' : '';
+    }
+
+    protected function isSubQuery($query)
+    {
+        return substr($query, 0, 1) == '(';
     }
 }

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -33,6 +33,12 @@ class OracleGrammar extends Grammar
      */
     protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
 
+
+    /**
+     * @var string
+     */
+    protected $schema_prefix = '';
+
     /**
      * Compile a create table command.
      *
@@ -690,5 +696,36 @@ class OracleGrammar extends Grammar
         }
 
         return $value !== '*' ? sprintf($this->wrapper, $value) : $value;
+    }
+
+    /**
+     * Wrap a table in keyword identifiers.
+     *
+     * @param  mixed   $table
+     * @return string
+     */
+    public function wrapTable($table)
+    {
+        return $this->getSchemaPrefix().parent::wrapTable($table);
+    }
+
+
+    /**
+     * Set the shema prefix
+     *
+     * @param string $prefix
+     */
+    public function setSchemaPrefix($prefix)
+    {
+        $this->schema_prefix = $prefix;
+    }
+
+    /**
+     * Return the schema prefix
+     * @return string
+     */
+    public function getSchemaPrefix()
+    {
+        return !empty($this->schema_prefix) ? $this->schema_prefix . '.' : '';
     }
 }

--- a/src/config/oracle.php
+++ b/src/config/oracle.php
@@ -2,14 +2,15 @@
 
 return [
     'oracle' => [
-        'driver'   => 'oracle',
-        'tns'      => env('DB_TNS', ''),
-        'host'     => env('DB_HOST', ''),
-        'port'     => env('DB_PORT', '1521'),
-        'database' => env('DB_DATABASE', ''),
-        'username' => env('DB_USERNAME', ''),
-        'password' => env('DB_PASSWORD', ''),
-        'charset'  => env('DB_CHARSET', 'AL32UTF8'),
-        'prefix'   => env('DB_PREFIX', ''),
+        'driver'        => 'oracle',
+        'tns'           => env('DB_TNS', ''),
+        'host'          => env('DB_HOST', ''),
+        'port'          => env('DB_PORT', '1521'),
+        'database'      => env('DB_DATABASE', ''),
+        'username'      => env('DB_USERNAME', ''),
+        'password'      => env('DB_PASSWORD', ''),
+        'charset'       => env('DB_CHARSET', 'AL32UTF8'),
+        'prefix'        => env('DB_PREFIX', ''),
+        'prefix_schema' => env('DB_SCHEMA_PREFIX', ''),
     ],
 ];


### PR DESCRIPTION
I need to make the schema prefix before the table name :

````sql
SELECT * FROM MySchema.PROFILE WHERE 1;
```

I need to add MySchema. To do this I create  a new method `withSchemaPrefix ` and it called in `withTablePrefix `.

I create a new config to ` 'prefix_schema' => env('DB_SCHEMA_PREFIX', ''),`

Regards,
Maxime