### PR TITLE
[Proposal] Auto increment primary key using custom sequence without trigger.

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -158,7 +158,11 @@ class OracleGrammar extends Grammar
             $sequence = 'id';
         }
 
-        $values[$sequence] = null;
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[3]['object'];
+
+        if (method_exists($backtrace, 'getModel')) {
+            $values[$sequence] = null;
+        }
 
         return $this->compileInsert($query, $values) . ' returning ' . $this->wrap($sequence) . ' into ?';
     }

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -161,7 +161,10 @@ class OracleGrammar extends Grammar
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[3]['object'];
 
         if (method_exists($backtrace, 'getModel')) {
-            $values[$sequence] = null;
+            $model = $backtrace->getModel();
+            if ($model->sequence && ! isset($values[$model->getKeyName()]) && $model->incrementing) {
+                $values[$sequence] = null;
+            }
         }
 
         return $this->compileInsert($query, $values) . ' returning ' . $this->wrap($sequence) . ' into ?';

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -158,6 +158,8 @@ class OracleGrammar extends Grammar
             $sequence = 'id';
         }
 
+        $values[$sequence] = null;
+
         return $this->compileInsert($query, $values) . ' returning ' . $this->wrap($sequence) . ' into ?';
     }
 

--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -12,9 +12,9 @@ class OracleProcessor extends Processor
      * Process an "insert get ID" query.
      *
      * @param  Builder $query
-     * @param  string $sql
-     * @param  array $values
-     * @param  string $sequence
+     * @param  string  $sql
+     * @param  array   $values
+     * @param  string  $sequence
      * @return int
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
@@ -24,8 +24,27 @@ class OracleProcessor extends Processor
 
         $statement = $this->prepareStatement($query, $sql);
 
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[3]['object'];
-        $builder = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[2]['args'];
+        $values = $this->incrementBySequence($values, $sequence);
+
+        $parameter = $this->bindValues($values, $statement, $parameter);
+
+        $statement->bindParam($parameter, $id, PDO::PARAM_INT, 10);
+        $statement->execute();
+
+        return (int) $id;
+    }
+
+    /**
+     * Insert a new record and get the value of the primary key.
+     *
+     * @param array $values
+     * @param string $sequence
+     * @return array
+     */
+    protected function incrementBySequence(array $values, $sequence)
+    {
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 5)[4]['object'];
+        $builder = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 5)[3]['args'];
 
         if (! isset($builder[1][0][$sequence])) {
             if (method_exists($backtrace, 'getModel')) {
@@ -36,11 +55,7 @@ class OracleProcessor extends Processor
             }
         }
 
-        $parameter = $this->bindValues($values, $statement, $parameter);
-        $statement->bindParam($parameter, $id, PDO::PARAM_INT, 10);
-        $statement->execute();
-
-        return (int) $id;
+        return $values;
     }
 
     /**

--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -23,6 +23,15 @@ class OracleProcessor extends Processor
         $parameter = 0;
         $statement = $this->prepareStatement($query, $sql);
 
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[3]['object'];
+
+        if (method_exists($backtrace, 'getModel')) {
+            $model = $backtrace->getModel();
+            if($model->sequence && !isset($values[$model->getKeyName()]) && $model->incrementing) {
+                $values[] = $model->getConnection()->getSequence()->nextValue($model->sequence);
+            }
+        }
+
         $parameter = $this->bindValues($values, $statement, $parameter);
         $statement->bindParam($parameter, $id, PDO::PARAM_INT, 10);
         $statement->execute();

--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -21,14 +21,18 @@ class OracleProcessor extends Processor
     {
         $id        = 0;
         $parameter = 0;
+
         $statement = $this->prepareStatement($query, $sql);
 
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[3]['object'];
+        $builder = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 4)[2]['args'];
 
-        if (method_exists($backtrace, 'getModel')) {
-            $model = $backtrace->getModel();
-            if($model->sequence && !isset($values[$model->getKeyName()]) && $model->incrementing) {
-                $values[] = $model->getConnection()->getSequence()->nextValue($model->sequence);
+        if (! isset($builder[1][0][$sequence])) {
+            if (method_exists($backtrace, 'getModel')) {
+                $model = $backtrace->getModel();
+                if ($model->sequence && $model->incrementing) {
+                    $values[] = (int)$model->getConnection()->getSequence()->nextValue($model->sequence);
+                }
             }
         }
 


### PR DESCRIPTION
Just add sequence on your model and you're done!
```php
public $sequence = 'custom_seq';
```

Code feels like it still can be improved. But for now this is just something quick.

## Eloquent Models
```php
$producer = new User();
$producer->name = 'Doe, John M.';
$producer->save();

// Get Entity / Model ID
$id = $producer->id
```

## Conditions to work

Just override $primaryKey and add public $sequence to your eloquent models
```php
protected $primaryKey = 'customid';
public $sequence = 'custom_seq';
public $incrementing = true; // true by default 
```

Credits to @yajra for pointing where to place this.