### PR TITLE
Refactor the schema prefix and fix user_tables

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -33,7 +33,7 @@ class OracleGrammar extends Grammar
         $q          = clone $query;
         $q->columns = [];
         $q->selectRaw('1 as "exists"')
-          ->whereRaw("rownum = 1");
+            ->whereRaw("rownum = 1");
 
         return $this->compileSelect($q);
     }
@@ -209,7 +209,7 @@ class OracleGrammar extends Grammar
         }
         $parameters = implode(', ', $value);
 
-        return "insert into " . $this->getSchemaPrefix() . "$table ($columns) values $parameters";
+        return "insert into $table ($columns) values $parameters";
     }
 
     /**
@@ -250,7 +250,7 @@ class OracleGrammar extends Grammar
         $value      = array_merge($value, $binaryValue);
         $parameters = implode(', ', array_filter($value));
 
-        return "insert into " . $this->getSchemaPrefix() . "$table ($columns) values ($parameters) returning " . $binaryColumns . ', ' . $this->wrap($sequence) . ' into ' . $binaryParameters . ', ?';
+        return "insert into $table ($columns) values ($parameters) returning " . $binaryColumns . ', ' . $this->wrap($sequence) . ' into ' . $binaryParameters . ', ?';
     }
 
     /**
@@ -309,62 +309,10 @@ class OracleGrammar extends Grammar
         // intended records are updated by the SQL statements we generate to run.
         $where = $this->compileWheres($query);
 
-        return "update " . $this->getSchemaPrefix() . "{$table}{$joins} set $columns$binarySql $where returning " . $binaryColumns . ', ' . $this->wrap($sequence) . ' into ' . $binaryParameters . ', ?';
+        return "update {$table}{$joins} set $columns$binarySql $where returning " . $binaryColumns . ', ' . $this->wrap($sequence) . ' into ' . $binaryParameters . ', ?';
     }
 
-    /**
-     * Compile a delete statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder $query
-     * @return string
-     */
-    public function compileDelete(Builder $query)
-    {
-        $table = $this->wrapTable($query->from);
 
-        $where = is_array($query->wheres) ? $this->compileWheres($query) : '';
-
-        return trim("delete from " . $this->getSchemaPrefix() . "$table " . $where);
-    }
-
-    /**
-     * Compile an update statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder $query
-     * @param  array $values
-     * @return string
-     */
-    public function compileUpdate(Builder $query, $values)
-    {
-        $table = $this->wrapTable($query->from);
-
-        // Each one of the columns in the update statements needs to be wrapped in the
-        // keyword identifiers, also a place-holder needs to be created for each of
-        // the values in the list of bindings so we can make the sets statements.
-        $columns = [];
-
-        foreach ($values as $key => $value) {
-            $columns[] = $this->wrap($key) . ' = ' . $this->parameter($value);
-        }
-
-        $columns = implode(', ', $columns);
-
-        // If the query has any "join" clauses, we will setup the joins on the builder
-        // and compile them so we can attach them to this update, as update queries
-        // can get join statements to attach to other tables when they're needed.
-        if (isset($query->joins)) {
-            $joins = ' ' . $this->compileJoins($query, $query->joins);
-        } else {
-            $joins = '';
-        }
-
-        // Of course, update queries may also be constrained by where clauses so we'll
-        // need to compile the where clauses and attach it to the query so only the
-        // intended records are updated by the SQL statements we generate to run.
-        $where = $this->compileWheres($query);
-
-        return trim("update " . $this->getSchemaPrefix() . "{$table}{$joins} set $columns $where");
-    }
 
     /**
      * Compile the lock into SQL.
@@ -454,35 +402,6 @@ class OracleGrammar extends Grammar
         return $value !== '*' ? sprintf($this->wrapper, $value) : $value;
     }
 
-    /**
-     * Compile the "from" portion of the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder $query
-     * @param  string $table
-     * @return string
-     */
-    protected function compileFrom(Builder $query, $table)
-    {
-
-        $query = $this->wrapTable($table);
-
-        if ($this->isSubQuery($query)) {
-            return 'from ' . $this->wrapTable($table);
-        }
-
-        return 'from ' . $this->getSchemaPrefix() . $this->wrapTable($table);
-    }
-
-    /**
-     * Check if given query is a sub-query.
-     *
-     * @param string $query
-     * @return bool
-     */
-    protected function isSubQuery($query)
-    {
-        return substr($query, 0, 1) == '(';
-    }
 
     /**
      * Return the schema prefix
@@ -502,5 +421,21 @@ class OracleGrammar extends Grammar
     public function setSchemaPrefix($prefix)
     {
         $this->schema_prefix = $prefix;
+    }
+
+
+    /**
+     * Wrap a table in keyword identifiers.
+     *
+     * @param  \Illuminate\Database\Query\Expression|string  $table
+     * @return string
+     */
+    public function wrapTable($table)
+    {
+        if ($this->isExpression($table)) {
+            return $this->getValue($table);
+        }
+
+        return $this->getSchemaPrefix() .$this->wrap($this->tablePrefix.$table, true);
     }
 }

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -158,7 +158,7 @@ class OracleGrammar extends Grammar
      */
     public function compileTableExists()
     {
-        return "select * from user_tables where upper(table_name) = upper(?)";
+        return "select * from all_tables where upper(table_name) = upper(?)";
     }
 
     /**
@@ -168,7 +168,7 @@ class OracleGrammar extends Grammar
      */
     public function compileColumnExists($table)
     {
-        return "select column_name from user_tab_columns where table_name = upper('" . $table . "')";
+        return "select column_name from all_tab_cols where table_name = upper('" . $table . "')";
     }
 
     /**

--- a/tests/Oci8SchemaGrammarTest.php
+++ b/tests/Oci8SchemaGrammarTest.php
@@ -263,7 +263,7 @@ class Oci8SchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testCompileTableExistsMethod()
     {
         $grammar  = $this->getGrammar();
-        $expected = 'select * from user_tables where upper(table_name) = upper(?)';
+        $expected = 'select * from all_tables where upper(table_name) = upper(?)';
         $sql      = $grammar->compileTableExists();
         $this->assertEquals($expected, $sql);
     }
@@ -271,7 +271,7 @@ class Oci8SchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testCompileColumnExistsMethod()
     {
         $grammar  = $this->getGrammar();
-        $expected = 'select column_name from user_tab_columns where table_name = upper(\'test_table\')';
+        $expected = 'select column_name from all_tab_cols where table_name = upper(\'test_table\')';
         $sql      = $grammar->compileColumnExists("test_table");
         $this->assertEquals($expected, $sql);
     }


### PR DESCRIPTION
Refactor the schema prefix. I put the schema prefix in wrapTable like the Schema/OracleGrammar. 
I removed the unused method override only for the prefix method.


Use `all_tab_cols`/`all_tables` instead of `user_tab_columns`/`user_tables` to allow querying tables that aren’t in the same schema that the currently connected user