### PR TITLE
Fix 'user' param when creating a Doctrine connection

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -189,7 +189,7 @@ class Oci8Connection extends Connection
     {
         $driver = $this->getDoctrineDriver();
 
-        $data = ['pdo' => $this->getPdo(), 'user' => $this->getConfig('database')];
+        $data = ['pdo' => $this->getPdo(), 'user' => $this->getConfig('username')];
 
         return new DoctrineConnection($data, $driver);
     }


### PR DESCRIPTION
It turns out the the produced Doctrine connetion was returning the database name as 'user' parameter, thus confusing Doctrine's SchemaManager when returning a table's columns.