### PR TITLE
Added option for skipping setSessionVars.

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -42,6 +42,10 @@ class Oci8ServiceProvider extends ServiceProvider
             $connection = $connector->connect($config);
             $db         = new Oci8Connection($connection, $config["database"], $config["prefix"], $config);
 
+            if (!empty($config['skip_session_vars'])) {
+                return $db;
+            }
+
             // set oracle session variables
             $sessionVars = [
                 'NLS_TIME_FORMAT'         => 'HH24:MI:SS',


### PR DESCRIPTION
Sometimes you may not need to set the session variables, for example when none of your queries deal with date or timestamp fields.