### PR TITLE
[5.3] Implement oracle user provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ This will copy the configuration file to `config/oracle.php`.
 
 And run your laravel installation...
 
+## [Laravel 5.2++] Oracle User Provider
+When using oracle, we may encounter a problem on authentication because oracle queries are case sensitive by default. 
+By using this oracle user provider, we will now be able to avoid user issues when logging in and doing a forgot password failure because of case sensitive search.
+
+To use, just update `auth.php` config and set the driver to `oracle`
+```php
+'providers' => [
+	'users' => [
+		'driver' => 'oracle',
+		'model' => App\User::class,
+	],
+]
+```
 
 ## Credits
 

--- a/src/Oci8/Auth/OracleUserProvider.php
+++ b/src/Oci8/Auth/OracleUserProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Yajra\Oci8\Auth;
+
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Support\Str;
+
+class OracleUserProvider extends EloquentUserProvider
+{
+    /**
+     * Retrieve a user by the given credentials.
+     *
+     * @param  array $credentials
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByCredentials(array $credentials)
+    {
+        if (empty($credentials)) {
+            return;
+        }
+
+        // First we will add each credential element to the query as a where clause.
+        // Then we can execute the query and, if we found a user, return it in a
+        // Eloquent User "model" that will be utilized by the Guard instances.
+        $query = $this->createModel()->newQuery();
+
+        foreach ($credentials as $key => $value) {
+            if (! Str::contains($key, 'password')) {
+                $query->whereRaw("upper({$key}) = upper(?)", [$value]);
+            }
+        }
+
+        return $query->first();
+    }
+}

--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -3,7 +3,9 @@
 namespace Yajra\Oci8;
 
 use Illuminate\Support\ServiceProvider;
+use Yajra\Oci8\Auth\OracleUserProvider;
 use Yajra\Oci8\Connectors\OracleConnector as Connector;
+use Illuminate\Support\Facades\Auth;
 
 class Oci8ServiceProvider extends ServiceProvider
 {
@@ -22,6 +24,10 @@ class Oci8ServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/oracle.php' => config_path('oracle.php'),
         ], 'oracle');
+
+        Auth::provider('oracle', function ($app, array $config) {
+            return new OracleUserProvider($app['hash'], $config['model']);
+        });
     }
 
     /**


### PR DESCRIPTION
When using oracle, we may encounter a problem on authentication because oracle queries are case sensitive by default. 

By using this oracle user provider, we will now be able to avoid user issues when logging in and doing a forgot password failure because of case sensitive search.

To use, just update `auth.php` config and set the driver to `oracle`
```php
'providers' => [
	'users' => [
		'driver' => 'oracle',
		'model' => App\User::class,
	],
]
