### PR TITLE
[BC][Security] Implement escaping of column name.

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -165,7 +165,7 @@ class OracleGrammar extends Grammar
     }
 
     /**
-     * Return the schema prefix
+     * Return the schema prefix.
      *
      * @return string
      */
@@ -175,7 +175,7 @@ class OracleGrammar extends Grammar
     }
 
     /**
-     * Set the shema prefix
+     * Set the schema prefix.
      *
      * @param string $prefix
      */

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -161,7 +161,13 @@ class OracleGrammar extends Grammar
             $table = str_replace(' as ', ' ', $table);
         }
 
-        return $this->getSchemaPrefix() . $this->tablePrefix . $table;
+        $tableName = $this->wrap($this->tablePrefix . $table, true);
+        $segments  = explode(' ', $table);
+        if (count($segments) > 1) {
+            $tableName = $this->wrap($this->tablePrefix . $segments[0]) . ' ' . $segments[1];
+        }
+
+        return $this->getSchemaPrefix() . $tableName;
     }
 
     /**
@@ -171,7 +177,7 @@ class OracleGrammar extends Grammar
      */
     public function getSchemaPrefix()
     {
-        return ! empty($this->schema_prefix) ? $this->schema_prefix . '.' : '';
+        return ! empty($this->schema_prefix) ? $this->wrapValue($this->schema_prefix) . '.' : '';
     }
 
     /**
@@ -182,6 +188,23 @@ class OracleGrammar extends Grammar
     public function setSchemaPrefix($prefix)
     {
         $this->schema_prefix = $prefix;
+    }
+
+    /**
+     * Wrap a single string in keyword identifiers.
+     *
+     * @param  string $value
+     * @return string
+     */
+    protected function wrapValue($value)
+    {
+        if ($value === '*') {
+            return $value;
+        }
+
+        $value = $this->isReserved($value) ? Str::lower($value) : Str::upper($value);
+
+        return '"' . str_replace('"', '""', $value) . '"';
     }
 
     /**
@@ -423,22 +446,5 @@ class OracleGrammar extends Grammar
         $value = $this->parameter($where['value']);
 
         return "extract ($type from {$this->wrap($where['column'])}) {$where['operator']} $value";
-    }
-
-    /**
-     * Wrap a single string in keyword identifiers.
-     *
-     * @param  string $value
-     * @return string
-     */
-    protected function wrapValue($value)
-    {
-        if ($value === '*') {
-            return $value;
-        }
-
-        $value = $this->isReserved($value) ? Str::lower($value) : Str::upper($value);
-
-        return '"' . str_replace('"', '""', $value) . '"';
     }
 }

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -4,6 +4,7 @@ namespace Yajra\Oci8\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Support\Str;
 use Yajra\Oci8\OracleReservedWords;
 
 class OracleGrammar extends Grammar
@@ -160,7 +161,7 @@ class OracleGrammar extends Grammar
             $table = str_replace(' as ', ' ', $table);
         }
 
-        return $this->getSchemaPrefix() . $this->wrap($this->tablePrefix . $table, true);
+        return $this->getSchemaPrefix() . $this->tablePrefix . $table;
     }
 
     /**
@@ -432,10 +433,12 @@ class OracleGrammar extends Grammar
      */
     protected function wrapValue($value)
     {
-        if ($this->isReserved($value)) {
-            return parent::wrapValue($value);
+        if ($value === '*') {
+            return $value;
         }
 
-        return $value !== '*' ? sprintf($this->wrapper, $value) : $value;
+        $value = $this->isReserved($value) ? Str::lower($value) : Str::upper($value);
+
+        return '"' . str_replace('"', '""', $value) . '"';
     }
 }

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -16,7 +16,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users');
-        $this->assertEquals('select * from users', $builder->toSql());
+        $this->assertEquals('select * from "USERS"', $builder->toSql());
     }
 
     protected function getBuilder()
@@ -31,14 +31,14 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('exists', 'drop', 'group')->from('users');
-        $this->assertEquals('select "exists", "drop", "group" from users', $builder->toSql());
+        $this->assertEquals('select "exists", "drop", "group" from "USERS"', $builder->toSql());
     }
 
     public function testAddingSelects()
     {
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
-        $this->assertEquals('select "FOO", "BAR", "BAZ", "BOOM" from users', $builder->toSql());
+        $this->assertEquals('select "FOO", "BAR", "BAZ", "BOOM" from "USERS"', $builder->toSql());
     }
 
     public function testBasicSelectWithPrefix()
@@ -46,35 +46,49 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->select('*')->from('users');
-        $this->assertEquals('select * from prefix_users', $builder->toSql());
+        $this->assertEquals('select * from "PREFIX_USERS"', $builder->toSql());
     }
 
     public function testBasicSelectDistinct()
     {
         $builder = $this->getBuilder();
         $builder->distinct()->select('foo', 'bar')->from('users');
-        $this->assertEquals('select distinct "FOO", "BAR" from users', $builder->toSql());
+        $this->assertEquals('select distinct "FOO", "BAR" from "USERS"', $builder->toSql());
     }
 
     public function testBasicAlias()
     {
         $builder = $this->getBuilder();
         $builder->select('foo as bar')->from('users');
-        $this->assertEquals('select "FOO" as "BAR" from users', $builder->toSql());
+        $this->assertEquals('select "FOO" as "BAR" from "USERS"', $builder->toSql());
     }
 
-    public function testBasicTableWrappingReservedWords()
+    public function testBasicSchemaWrapping()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('acme.users');
+        $this->assertEquals('select * from "ACME"."USERS"', $builder->toSql());
+    }
+
+    public function testBasicSchemaWrappingReservedWords()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('schema.users');
-        $this->assertEquals('select * from schema.users', $builder->toSql());
+        $this->assertEquals('select * from "schema"."USERS"', $builder->toSql());
+    }
+
+    public function testBasicColumnWrappingReservedWords()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('order')->from('users');
+        $this->assertEquals('select "order" from "USERS"', $builder->toSql());
     }
 
     public function testBasicWheres()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
-        $this->assertEquals('select * from users where "ID" = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -82,7 +96,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('blob', '=', 1);
-        $this->assertEquals('select * from users where "blob" = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "blob" = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -90,12 +104,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', [1, 2]);
-        $this->assertEquals('select * from users where "ID" between ? and ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotBetween('id', [1, 2]);
-        $this->assertEquals('select * from users where "ID" not between ? and ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" not between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
@@ -103,7 +117,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
-        $this->assertEquals('select * from users where "ID" = ? or "EMAIL" = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ? or "EMAIL" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -111,7 +125,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereRaw('id = ? or email = ?', [1, 'foo']);
-        $this->assertEquals('select * from users where id = ? or email = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where id = ? or email = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -119,7 +133,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereRaw('email = ?', ['foo']);
-        $this->assertEquals('select * from users where "ID" = ? or email = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ? or email = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -127,12 +141,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where "ID" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where "ID" = ? or "ID" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ? or "ID" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
@@ -140,12 +154,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where "ID" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where "ID" = ? or "ID" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ? or "ID" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
@@ -154,7 +168,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from users where "ID" = ? union select * from users where "ID" = ?',
+        $this->assertEquals('select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
@@ -164,7 +178,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from users where "ID" = ? union all select * from users where "ID" = ?',
+        $this->assertEquals('select * from "USERS" where "ID" = ? union all select * from "USERS" where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
@@ -175,7 +189,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('select * from users where "ID" = ? union select * from users where "ID" = ? union select * from users where "ID" = ?',
+        $this->assertEquals('select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
@@ -186,7 +200,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('select * from users where "ID" = ? union all select * from users where "ID" = ? union all select * from users where "ID" = ?',
+        $this->assertEquals('select * from "USERS" where "ID" = ? union all select * from "USERS" where "ID" = ? union all select * from "USERS" where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
@@ -197,7 +211,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->whereIn('id', function ($q) {
             $q->select('id')->from('users')->where('age', '>', 25)->take(3);
         });
-        $this->assertEquals('select * from users where "ID" in (select t2.* from ( select rownum AS "rn", t1.* from (select "ID" from users where "AGE" > ?) t1 ) t2 where t2."rn" between 1 and 3)',
+        $this->assertEquals('select * from "USERS" where "ID" in (select t2.* from ( select rownum AS "rn", t1.* from (select "ID" from "USERS" where "AGE" > ?) t1 ) t2 where t2."rn" between 1 and 3)',
             $builder->toSql());
         $this->assertEquals([25], $builder->getBindings());
 
@@ -205,7 +219,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->whereNotIn('id', function ($q) {
             $q->select('id')->from('users')->where('age', '>', 25)->take(3);
         });
-        $this->assertEquals('select * from users where "ID" not in (select t2.* from ( select rownum AS "rn", t1.* from (select "ID" from users where "AGE" > ?) t1 ) t2 where t2."rn" between 1 and 3)',
+        $this->assertEquals('select * from "USERS" where "ID" not in (select t2.* from ( select rownum AS "rn", t1.* from (select "ID" from "USERS" where "AGE" > ?) t1 ) t2 where t2."rn" between 1 and 3)',
             $builder->toSql());
         $this->assertEquals([25], $builder->getBindings());
     }
@@ -214,12 +228,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull('id');
-        $this->assertEquals('select * from users where "ID" is null', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" is null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull('id');
-        $this->assertEquals('select * from users where "ID" = ? or "ID" is null', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ? or "ID" is null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -227,12 +241,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull('id');
-        $this->assertEquals('select * from users where "ID" is not null', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" is not null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
-        $this->assertEquals('select * from users where "ID" > ? or "ID" is not null', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" > ? or "ID" is not null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -240,18 +254,18 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('id', 'email');
-        $this->assertEquals('select * from users group by "ID", "EMAIL"', $builder->toSql());
+        $this->assertEquals('select * from "USERS" group by "ID", "EMAIL"', $builder->toSql());
     }
 
     public function testOrderBys()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
-        $this->assertEquals('select * from users order by "EMAIL" asc, "AGE" desc', $builder->toSql());
+        $this->assertEquals('select * from "USERS" order by "EMAIL" asc, "AGE" desc', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderByRaw('age ? desc', ['bar']);
-        $this->assertEquals('select * from users order by "EMAIL" asc, age ? desc', $builder->toSql());
+        $this->assertEquals('select * from "USERS" order by "EMAIL" asc, age ? desc', $builder->toSql());
         $this->assertEquals(['bar'], $builder->getBindings());
     }
 
@@ -259,57 +273,57 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('email', '>', 1);
-        $this->assertEquals('select * from users having "EMAIL" > ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" having "EMAIL" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
-        $this->assertEquals('select * from users group by "EMAIL" having "EMAIL" > ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" group by "EMAIL" having "EMAIL" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
-        $this->assertEquals('select "EMAIL" as "FOO_EMAIL" from users having "FOO_EMAIL" > ?', $builder->toSql());
+        $this->assertEquals('select "EMAIL" as "FOO_EMAIL" from "USERS" having "FOO_EMAIL" > ?', $builder->toSql());
     }
 
     public function testRawHavings()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
-        $this->assertEquals('select * from users having user_foo < user_bar', $builder->toSql());
+        $this->assertEquals('select * from "USERS" having user_foo < user_bar', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
-        $this->assertEquals('select * from users having "BAZ" = ? or user_foo < user_bar', $builder->toSql());
+        $this->assertEquals('select * from "USERS" having "BAZ" = ? or user_foo < user_bar', $builder->toSql());
     }
 
     public function testLimitsAndOffsets()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->offset(10);
-        $this->assertEquals('select * from (select * from users) where rownum >= 11', $builder->toSql());
+        $this->assertEquals('select * from (select * from "USERS") where rownum >= 11', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->offset(5)->limit(10);
-        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from users) t1 ) t2 where t2."rn" between 6 and 15',
+        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" between 6 and 15',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->skip(5)->take(10);
-        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from users) t1 ) t2 where t2."rn" between 6 and 15',
+        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" between 6 and 15',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->skip(-5)->take(10);
-        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from users) t1 ) t2 where t2."rn" between 1 and 10',
+        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" between 1 and 10',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(2, 15);
-        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from users) t1 ) t2 where t2."rn" between 16 and 30',
+        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" between 16 and 30',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(-2, 15);
-        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from users) t1 ) t2 where t2."rn" between 1 and 15',
+        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" between 1 and 15',
             $builder->toSql());
     }
 
@@ -317,7 +331,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhere('name', 'foo');
-        $this->assertEquals('select * from users where "ID" = ? or "NAME" = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "ID" = ? or "NAME" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -327,7 +341,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('email', '=', 'foo')->orWhere(function ($q) {
             $q->where('name', '=', 'bar')->where('age', '=', 25);
         });
-        $this->assertEquals('select * from users where "EMAIL" = ? or ("NAME" = ? and "AGE" = ?)', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "EMAIL" = ? or ("NAME" = ? and "AGE" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
@@ -338,7 +352,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
             $q->select(new Raw('max(id)'))->from('users')->where('email', '=', 'bar');
         });
 
-        $this->assertEquals('select * from users where "EMAIL" = ? or "ID" = (select max(id) from users where "EMAIL" = ?)',
+        $this->assertEquals('select * from "USERS" where "EMAIL" = ? or "ID" = (select max(id) from "USERS" where "EMAIL" = ?)',
             $builder->toSql());
         $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
     }
@@ -349,28 +363,28 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('orders')->whereExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where exists (select * from products where products."ID" = orders.id)',
+        $this->assertEquals('select * from "ORDERS" where exists (select * from "PRODUCTS" where "PRODUCTS"."ID" = orders.id)',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereNotExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where not exists (select * from products where products."ID" = orders.id)',
+        $this->assertEquals('select * from "ORDERS" where not exists (select * from "PRODUCTS" where "PRODUCTS"."ID" = orders.id)',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where "ID" = ? or exists (select * from products where products."ID" = orders.id)',
+        $this->assertEquals('select * from "ORDERS" where "ID" = ? or exists (select * from "PRODUCTS" where "PRODUCTS"."ID" = orders.id)',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where "ID" = ? or not exists (select * from products where products."ID" = orders.id)',
+        $this->assertEquals('select * from "ORDERS" where "ID" = ? or not exists (select * from "PRODUCTS" where "PRODUCTS"."ID" = orders.id)',
             $builder->toSql());
     }
 
@@ -381,7 +395,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->from('users')
                 ->join('contacts', 'users.id', '=', 'contacts.id')
                 ->leftJoin('photos', 'users.id', '=', 'photos.id');
-        $this->assertEquals('select * from users inner join contacts on users."ID" = contacts."ID" left join photos on users."ID" = photos."ID"',
+        $this->assertEquals('select * from "USERS" inner join "CONTACTS" on "USERS"."ID" = "CONTACTS"."ID" left join "PHOTOS" on "USERS"."ID" = "PHOTOS"."ID"',
             $builder->toSql());
 
         $builder = $this->getBuilder();
@@ -389,7 +403,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->from('users')
                 ->leftJoinWhere('photos', 'users.id', '=', 'bar')
                 ->joinWhere('photos', 'users.id', '=', 'foo');
-        $this->assertEquals('select * from users left join photos on users."ID" = ? inner join photos on users."ID" = ?',
+        $this->assertEquals('select * from "USERS" left join "PHOTOS" on "USERS"."ID" = ? inner join "PHOTOS" on "USERS"."ID" = ?',
             $builder->toSql());
         $this->assertEquals(['bar', 'foo'], $builder->getBindings());
     }
@@ -400,14 +414,14 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orOn('users.name', '=', 'contacts.name');
         });
-        $this->assertEquals('select * from users inner join contacts on users."ID" = contacts."ID" or users."NAME" = contacts."NAME"',
+        $this->assertEquals('select * from "USERS" inner join "CONTACTS" on "USERS"."ID" = "CONTACTS"."ID" or "USERS"."NAME" = "CONTACTS"."NAME"',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->where('users.id', '=', 'foo')->orWhere('users.name', '=', 'bar');
         });
-        $this->assertEquals('select * from users inner join contacts on users."ID" = ? or users."NAME" = ?',
+        $this->assertEquals('select * from "USERS" inner join "CONTACTS" on "USERS"."ID" = ? or "USERS"."NAME" = ?',
             $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
@@ -416,7 +430,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select(new Raw('substr(foo, 6)'))->from('users');
-        $this->assertEquals('select substr(foo, 6) from users', $builder->toSql());
+        $this->assertEquals('select substr(foo, 6) from "USERS"', $builder->toSql());
     }
 
     public function testFindReturnsFirstResultByID()
@@ -425,7 +439,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select * from (select * from users where "ID" = ?) where rownum = 1',
+                ->with('select * from (select * from "USERS" where "ID" = ?) where rownum = 1',
                     [1], true)
                 ->andReturn([['foo' => 'bar']]);
         $builder->getProcessor()
@@ -445,7 +459,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select * from (select * from users where "ID" = ?) where rownum = 1',
+                ->with('select * from (select * from "USERS" where "ID" = ?) where rownum = 1',
                     [1], true)
                 ->andReturn([['foo' => 'bar']]);
         $builder->getProcessor()
@@ -513,7 +527,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select count(*) as aggregate from users', [], true)
+                ->with('select count(*) as aggregate from "USERS"', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -527,7 +541,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')
                 ->once()
-                ->with('select 1 as "exists" from users where rownum = 1', [], true)
+                ->with('select 1 as "exists" from "USERS" where rownum = 1', [], true)
                 ->andReturn([['exists' => 1]]);
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);
@@ -539,7 +553,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select max("ID") as aggregate from users', [], true)
+                ->with('select max("ID") as aggregate from "USERS"', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -554,7 +568,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select min("ID") as aggregate from users', [], true)
+                ->with('select min("ID") as aggregate from "USERS"', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -569,7 +583,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select sum("ID") as aggregate from users', [], true)
+                ->with('select sum("ID") as aggregate from "USERS"', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -584,7 +598,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('insert')
                 ->once()
-                ->with('insert into users ("EMAIL") values (?)', ['foo'])
+                ->with('insert into "USERS" ("EMAIL") values (?)', ['foo'])
                 ->andReturn(true);
         $result = $builder->from('users')->insert(['email' => 'foo']);
         $this->assertTrue($result);
@@ -596,7 +610,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('insert')
                 ->once()
-                ->with('insert into users ("EMAIL") select ? from dual union all select ? from dual ', ['foo', 'foo'])
+                ->with('insert into "USERS" ("EMAIL") select ? from dual union all select ? from dual ', ['foo', 'foo'])
                 ->andReturn(true);
         $data[] = ['email' => 'foo'];
         $data[] = ['email' => 'foo'];
@@ -610,7 +624,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('processInsertGetId')
                 ->once()
-                ->with($builder, 'insert into users ("EMAIL") values (?) returning "ID" into ?', ['foo'], 'id')
+                ->with($builder, 'insert into "USERS" ("EMAIL") values (?) returning "ID" into ?', ['foo'], 'id')
                 ->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
         $this->assertEquals(1, $result);
@@ -623,7 +637,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->shouldReceive('saveLob')
                 ->once()
                 ->with($builder,
-                    'insert into users ("EMAIL", "MYBLOB") values (?, EMPTY_BLOB()) returning "MYBLOB", "ID" into ?, ?',
+                    'insert into "USERS" ("EMAIL", "MYBLOB") values (?, EMPTY_BLOB()) returning "MYBLOB", "ID" into ?, ?',
                     ['foo'], ['test data'])
                 ->andReturn(1);
         $result = $builder->from('users')->insertLob(['email' => 'foo'], ['myblob' => 'test data'], 'id');
@@ -636,7 +650,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('saveLob')
                 ->once()
-                ->with($builder, 'insert into users ("MYBLOB") values (EMPTY_BLOB()) returning "MYBLOB", "ID" into ?, ?', [],
+                ->with($builder, 'insert into "USERS" ("MYBLOB") values (EMPTY_BLOB()) returning "MYBLOB", "ID" into ?, ?', [],
                     ['test data'])
                 ->andReturn(1);
         $result = $builder->from('users')->insertLob([], ['myblob' => 'test data'], 'id');
@@ -650,7 +664,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->shouldReceive('saveLob')
                 ->once()
                 ->with($builder,
-                    'update users set "EMAIL" = ?, "MYBLOB" = EMPTY_BLOB() where "ID" = ? returning "MYBLOB", "ID" into ?, ?',
+                    'update "USERS" set "EMAIL" = ?, "MYBLOB" = EMPTY_BLOB() where "ID" = ? returning "MYBLOB", "ID" into ?, ?',
                     ['foo', 1],
                     ['test data'])
                 ->andReturn(1);
@@ -666,7 +680,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('saveLob')
                 ->once()
-                ->with($builder, 'update users set "MYBLOB" = EMPTY_BLOB() where "ID" = ? returning "MYBLOB", "ID" into ?, ?',
+                ->with($builder, 'update "USERS" set "MYBLOB" = EMPTY_BLOB() where "ID" = ? returning "MYBLOB", "ID" into ?, ?',
                     [1],
                     ['test data'])
                 ->andReturn(1);
@@ -682,7 +696,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('processInsertGetId')
                 ->once()
-                ->with($builder, 'insert into users ("EMAIL", "BAR") values (?, bar) returning "ID" into ?', ['foo'], 'id')
+                ->with($builder, 'insert into "USERS" ("EMAIL", "BAR") values (?, bar) returning "ID" into ?', ['foo'], 'id')
                 ->andReturn(1);
         $result = $builder->from('users')
                           ->insertGetId(['email' => 'foo', 'bar' => new Illuminate\Database\Query\Expression('bar')], 'id');
@@ -695,7 +709,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('insert')
                 ->once()
-                ->with('insert into users ("EMAIL") values (CURRENT TIMESTAMP)', [])
+                ->with('insert into "USERS" ("EMAIL") values (CURRENT TIMESTAMP)', [])
                 ->andReturn(true);
         $result = $builder->from('users')->insert(['email' => new Raw('CURRENT TIMESTAMP')]);
         $this->assertTrue($result);
@@ -707,7 +721,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('update')
                 ->once()
-                ->with('update users set "EMAIL" = ?, "NAME" = ? where "ID" = ?', ['foo', 'bar', 1])
+                ->with('update "USERS" set "EMAIL" = ?, "NAME" = ? where "ID" = ?', ['foo', 'bar', 1])
                 ->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
@@ -719,7 +733,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('update')
                 ->once()
-                ->with('update users inner join orders on users."ID" = orders."USER_ID" set "EMAIL" = ?, "NAME" = ? where users."ID" = ?',
+                ->with('update "USERS" inner join "ORDERS" on "USERS"."ID" = "ORDERS"."USER_ID" set "EMAIL" = ?, "NAME" = ? where "USERS"."ID" = ?',
                     ['foo', 'bar', 1])
                 ->andReturn(1);
         $result = $builder->from('users')
@@ -735,7 +749,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('update')
                 ->once()
-                ->with('update users set "EMAIL" = foo, "NAME" = ? where "ID" = ?', ['bar', 1])
+                ->with('update "USERS" set "EMAIL" = foo, "NAME" = ? where "ID" = ?', ['bar', 1])
                 ->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['email' => new Raw('foo'), 'name' => 'bar']);
         $this->assertEquals(1, $result);
@@ -747,7 +761,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('delete')
                 ->once()
-                ->with('delete from users where "EMAIL" = ?', ['foo'])
+                ->with('delete from "USERS" where "EMAIL" = ?', ['foo'])
                 ->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->delete();
         $this->assertEquals(1, $result);
@@ -756,7 +770,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('delete')
                 ->once()
-                ->with('delete from users where "ID" = ?', [1])
+                ->with('delete from "USERS" where "ID" = ?', [1])
                 ->andReturn(1);
         $result = $builder->from('users')->delete(1);
         $this->assertEquals(1, $result);
@@ -765,7 +779,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     public function testTruncateMethod()
     {
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table users', []);
+        $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "USERS"', []);
         $builder->from('users')->truncate();
     }
 
@@ -782,7 +796,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', null);
-        $this->assertEquals('select * from users where "FOO" is null', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "FOO" is null', $builder->toSql());
     }
 
     public function testDynamicWhere()
@@ -839,7 +853,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-        $this->assertEquals('select * from foo where "BAR" = ? for update', $builder->toSql());
+        $this->assertEquals('select * from "FOO" where "BAR" = ? for update', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -856,7 +870,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-20');
-        $this->assertEquals('select * from users where trunc("CREATED_AT") = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where trunc("CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => '2015-12-20'], $builder->getBindings());
     }
 
@@ -864,7 +878,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 20);
-        $this->assertEquals('select * from users where extract (day from "CREATED_AT") = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where extract (day from "CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => 20], $builder->getBindings());
     }
 
@@ -872,7 +886,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 12);
-        $this->assertEquals('select * from users where extract (month from "CREATED_AT") = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where extract (month from "CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => 12], $builder->getBindings());
     }
 
@@ -880,7 +894,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2015);
-        $this->assertEquals('select * from users where extract (year from "CREATED_AT") = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where extract (year from "CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => 2015], $builder->getBindings());
     }
 
@@ -938,7 +952,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select count(*) as aggregate from users', [], true)
+                ->with('select count(*) as aggregate from "USERS"', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -979,7 +993,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->orderBy('id', 'desc');
-        $this->assertEquals('select * from users where "ID" = ? union select * from users where "ID" = ? order by "ID" desc',
+        $this->assertEquals('select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ? order by "ID" desc',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -38,7 +38,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
-        $this->assertEquals('select foo, bar, baz, boom from users', $builder->toSql());
+        $this->assertEquals('select "FOO", "BAR", "BAZ", "BOOM" from users', $builder->toSql());
     }
 
     public function testBasicSelectWithPrefix()
@@ -53,32 +53,28 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->distinct()->select('foo', 'bar')->from('users');
-        $this->assertEquals('select distinct foo, bar from users', $builder->toSql());
+        $this->assertEquals('select distinct "FOO", "BAR" from users', $builder->toSql());
     }
 
     public function testBasicAlias()
     {
         $builder = $this->getBuilder();
         $builder->select('foo as bar')->from('users');
-        $this->assertEquals('select foo as bar from users', $builder->toSql());
+        $this->assertEquals('select "FOO" as "BAR" from users', $builder->toSql());
     }
 
     public function testBasicTableWrappingReservedWords()
     {
-        /**
-         * NOTE: this should not be allowed in real world app
-         * as Oracle will not allow creation of such objects.
-         */
         $builder = $this->getBuilder();
         $builder->select('*')->from('schema.users');
-        $this->assertEquals('select * from "schema".users', $builder->toSql());
+        $this->assertEquals('select * from schema.users', $builder->toSql());
     }
 
     public function testBasicWheres()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
-        $this->assertEquals('select * from users where id = ?', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -94,12 +90,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', [1, 2]);
-        $this->assertEquals('select * from users where id between ? and ?', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotBetween('id', [1, 2]);
-        $this->assertEquals('select * from users where id not between ? and ?', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" not between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
@@ -107,7 +103,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
-        $this->assertEquals('select * from users where id = ? or email = ?', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ? or "EMAIL" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -123,7 +119,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereRaw('email = ?', ['foo']);
-        $this->assertEquals('select * from users where id = ? or email = ?', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ? or email = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -131,12 +127,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where id in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where id = ? or id in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ? or "ID" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
@@ -144,12 +140,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where id not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from users where id = ? or id not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ? or "ID" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
@@ -158,7 +154,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from users where id = ? union select * from users where id = ?',
+        $this->assertEquals('select * from users where "ID" = ? union select * from users where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
@@ -168,7 +164,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from users where id = ? union all select * from users where id = ?',
+        $this->assertEquals('select * from users where "ID" = ? union all select * from users where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
@@ -179,7 +175,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('select * from users where id = ? union select * from users where id = ? union select * from users where id = ?',
+        $this->assertEquals('select * from users where "ID" = ? union select * from users where "ID" = ? union select * from users where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
@@ -190,7 +186,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('select * from users where id = ? union all select * from users where id = ? union all select * from users where id = ?',
+        $this->assertEquals('select * from users where "ID" = ? union all select * from users where "ID" = ? union all select * from users where "ID" = ?',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
@@ -201,7 +197,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->whereIn('id', function ($q) {
             $q->select('id')->from('users')->where('age', '>', 25)->take(3);
         });
-        $this->assertEquals('select * from users where id in (select t2.* from ( select rownum AS "rn", t1.* from (select id from users where age > ?) t1 ) t2 where t2."rn" between 1 and 3)',
+        $this->assertEquals('select * from users where "ID" in (select t2.* from ( select rownum AS "rn", t1.* from (select "ID" from users where "AGE" > ?) t1 ) t2 where t2."rn" between 1 and 3)',
             $builder->toSql());
         $this->assertEquals([25], $builder->getBindings());
 
@@ -209,7 +205,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->whereNotIn('id', function ($q) {
             $q->select('id')->from('users')->where('age', '>', 25)->take(3);
         });
-        $this->assertEquals('select * from users where id not in (select t2.* from ( select rownum AS "rn", t1.* from (select id from users where age > ?) t1 ) t2 where t2."rn" between 1 and 3)',
+        $this->assertEquals('select * from users where "ID" not in (select t2.* from ( select rownum AS "rn", t1.* from (select "ID" from users where "AGE" > ?) t1 ) t2 where t2."rn" between 1 and 3)',
             $builder->toSql());
         $this->assertEquals([25], $builder->getBindings());
     }
@@ -218,12 +214,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull('id');
-        $this->assertEquals('select * from users where id is null', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" is null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull('id');
-        $this->assertEquals('select * from users where id = ? or id is null', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ? or "ID" is null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -231,12 +227,12 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull('id');
-        $this->assertEquals('select * from users where id is not null', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" is not null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
-        $this->assertEquals('select * from users where id > ? or id is not null', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" > ? or "ID" is not null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -244,18 +240,18 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('id', 'email');
-        $this->assertEquals('select * from users group by id, email', $builder->toSql());
+        $this->assertEquals('select * from users group by "ID", "EMAIL"', $builder->toSql());
     }
 
     public function testOrderBys()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
-        $this->assertEquals('select * from users order by email asc, age desc', $builder->toSql());
+        $this->assertEquals('select * from users order by "EMAIL" asc, "AGE" desc', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderByRaw('age ? desc', ['bar']);
-        $this->assertEquals('select * from users order by email asc, age ? desc', $builder->toSql());
+        $this->assertEquals('select * from users order by "EMAIL" asc, age ? desc', $builder->toSql());
         $this->assertEquals(['bar'], $builder->getBindings());
     }
 
@@ -263,15 +259,15 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('email', '>', 1);
-        $this->assertEquals('select * from users having email > ?', $builder->toSql());
+        $this->assertEquals('select * from users having "EMAIL" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
-        $this->assertEquals('select * from users group by email having email > ?', $builder->toSql());
+        $this->assertEquals('select * from users group by "EMAIL" having "EMAIL" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
-        $this->assertEquals('select email as foo_email from users having foo_email > ?', $builder->toSql());
+        $this->assertEquals('select "EMAIL" as "FOO_EMAIL" from users having "FOO_EMAIL" > ?', $builder->toSql());
     }
 
     public function testRawHavings()
@@ -282,7 +278,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
-        $this->assertEquals('select * from users having baz = ? or user_foo < user_bar', $builder->toSql());
+        $this->assertEquals('select * from users having "BAZ" = ? or user_foo < user_bar', $builder->toSql());
     }
 
     public function testLimitsAndOffsets()
@@ -321,7 +317,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhere('name', 'foo');
-        $this->assertEquals('select * from users where id = ? or name = ?', $builder->toSql());
+        $this->assertEquals('select * from users where "ID" = ? or "NAME" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -331,7 +327,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('email', '=', 'foo')->orWhere(function ($q) {
             $q->where('name', '=', 'bar')->where('age', '=', 25);
         });
-        $this->assertEquals('select * from users where email = ? or (name = ? and age = ?)', $builder->toSql());
+        $this->assertEquals('select * from users where "EMAIL" = ? or ("NAME" = ? and "AGE" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
@@ -342,7 +338,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
             $q->select(new Raw('max(id)'))->from('users')->where('email', '=', 'bar');
         });
 
-        $this->assertEquals('select * from users where email = ? or id = (select max(id) from users where email = ?)',
+        $this->assertEquals('select * from users where "EMAIL" = ? or "ID" = (select max(id) from users where "EMAIL" = ?)',
             $builder->toSql());
         $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
     }
@@ -353,28 +349,28 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('orders')->whereExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where exists (select * from products where products.id = orders.id)',
+        $this->assertEquals('select * from orders where exists (select * from products where products."ID" = orders.id)',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereNotExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where not exists (select * from products where products.id = orders.id)',
+        $this->assertEquals('select * from orders where not exists (select * from products where products."ID" = orders.id)',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where id = ? or exists (select * from products where products.id = orders.id)',
+        $this->assertEquals('select * from orders where "ID" = ? or exists (select * from products where products."ID" = orders.id)',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('orders.id'));
         });
-        $this->assertEquals('select * from orders where id = ? or not exists (select * from products where products.id = orders.id)',
+        $this->assertEquals('select * from orders where "ID" = ? or not exists (select * from products where products."ID" = orders.id)',
             $builder->toSql());
     }
 
@@ -385,7 +381,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->from('users')
                 ->join('contacts', 'users.id', '=', 'contacts.id')
                 ->leftJoin('photos', 'users.id', '=', 'photos.id');
-        $this->assertEquals('select * from users inner join contacts on users.id = contacts.id left join photos on users.id = photos.id',
+        $this->assertEquals('select * from users inner join contacts on users."ID" = contacts."ID" left join photos on users."ID" = photos."ID"',
             $builder->toSql());
 
         $builder = $this->getBuilder();
@@ -393,7 +389,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->from('users')
                 ->leftJoinWhere('photos', 'users.id', '=', 'bar')
                 ->joinWhere('photos', 'users.id', '=', 'foo');
-        $this->assertEquals('select * from users left join photos on users.id = ? inner join photos on users.id = ?',
+        $this->assertEquals('select * from users left join photos on users."ID" = ? inner join photos on users."ID" = ?',
             $builder->toSql());
         $this->assertEquals(['bar', 'foo'], $builder->getBindings());
     }
@@ -404,14 +400,14 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orOn('users.name', '=', 'contacts.name');
         });
-        $this->assertEquals('select * from users inner join contacts on users.id = contacts.id or users.name = contacts.name',
+        $this->assertEquals('select * from users inner join contacts on users."ID" = contacts."ID" or users."NAME" = contacts."NAME"',
             $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->where('users.id', '=', 'foo')->orWhere('users.name', '=', 'bar');
         });
-        $this->assertEquals('select * from users inner join contacts on users.id = ? or users.name = ?',
+        $this->assertEquals('select * from users inner join contacts on users."ID" = ? or users."NAME" = ?',
             $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
@@ -429,7 +425,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select * from (select * from users where id = ?) where rownum = 1',
+                ->with('select * from (select * from users where "ID" = ?) where rownum = 1',
                     [1], true)
                 ->andReturn([['foo' => 'bar']]);
         $builder->getProcessor()
@@ -449,7 +445,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select * from (select * from users where id = ?) where rownum = 1',
+                ->with('select * from (select * from users where "ID" = ?) where rownum = 1',
                     [1], true)
                 ->andReturn([['foo' => 'bar']]);
         $builder->getProcessor()
@@ -543,7 +539,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select max(id) as aggregate from users', [], true)
+                ->with('select max("ID") as aggregate from users', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -558,7 +554,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select min(id) as aggregate from users', [], true)
+                ->with('select min("ID") as aggregate from users', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -573,7 +569,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('select')
                 ->once()
-                ->with('select sum(id) as aggregate from users', [], true)
+                ->with('select sum("ID") as aggregate from users', [], true)
                 ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
             return $results;
@@ -588,7 +584,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('insert')
                 ->once()
-                ->with('insert into users (email) values (?)', ['foo'])
+                ->with('insert into users ("EMAIL") values (?)', ['foo'])
                 ->andReturn(true);
         $result = $builder->from('users')->insert(['email' => 'foo']);
         $this->assertTrue($result);
@@ -600,7 +596,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('insert')
                 ->once()
-                ->with('insert into users (email) select ? from dual union all select ? from dual ', ['foo', 'foo'])
+                ->with('insert into users ("EMAIL") select ? from dual union all select ? from dual ', ['foo', 'foo'])
                 ->andReturn(true);
         $data[] = ['email' => 'foo'];
         $data[] = ['email' => 'foo'];
@@ -614,7 +610,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('processInsertGetId')
                 ->once()
-                ->with($builder, 'insert into users (email) values (?) returning id into ?', ['foo'], 'id')
+                ->with($builder, 'insert into users ("EMAIL") values (?) returning "ID" into ?', ['foo'], 'id')
                 ->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
         $this->assertEquals(1, $result);
@@ -627,7 +623,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->shouldReceive('saveLob')
                 ->once()
                 ->with($builder,
-                    'insert into users (email, myblob) values (?, EMPTY_BLOB()) returning myblob, id into ?, ?',
+                    'insert into users ("EMAIL", "MYBLOB") values (?, EMPTY_BLOB()) returning "MYBLOB", "ID" into ?, ?',
                     ['foo'], ['test data'])
                 ->andReturn(1);
         $result = $builder->from('users')->insertLob(['email' => 'foo'], ['myblob' => 'test data'], 'id');
@@ -640,7 +636,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('saveLob')
                 ->once()
-                ->with($builder, 'insert into users (myblob) values (EMPTY_BLOB()) returning myblob, id into ?, ?', [],
+                ->with($builder, 'insert into users ("MYBLOB") values (EMPTY_BLOB()) returning "MYBLOB", "ID" into ?, ?', [],
                     ['test data'])
                 ->andReturn(1);
         $result = $builder->from('users')->insertLob([], ['myblob' => 'test data'], 'id');
@@ -654,7 +650,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
                 ->shouldReceive('saveLob')
                 ->once()
                 ->with($builder,
-                    'update users set email = ?, myblob = EMPTY_BLOB() where id = ? returning myblob, id into ?, ?',
+                    'update users set "EMAIL" = ?, "MYBLOB" = EMPTY_BLOB() where "ID" = ? returning "MYBLOB", "ID" into ?, ?',
                     ['foo', 1],
                     ['test data'])
                 ->andReturn(1);
@@ -670,7 +666,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('saveLob')
                 ->once()
-                ->with($builder, 'update users set myblob = EMPTY_BLOB() where id = ? returning myblob, id into ?, ?',
+                ->with($builder, 'update users set "MYBLOB" = EMPTY_BLOB() where "ID" = ? returning "MYBLOB", "ID" into ?, ?',
                     [1],
                     ['test data'])
                 ->andReturn(1);
@@ -686,11 +682,10 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()
                 ->shouldReceive('processInsertGetId')
                 ->once()
-                ->with($builder, 'insert into users (email, bar) values (?, bar) returning id into ?', ['foo'], 'id')
+                ->with($builder, 'insert into users ("EMAIL", "BAR") values (?, bar) returning "ID" into ?', ['foo'], 'id')
                 ->andReturn(1);
         $result = $builder->from('users')
-                          ->insertGetId(['email' => 'foo', 'bar' => new Illuminate\Database\Query\Expression('bar')],
-                              'id');
+                          ->insertGetId(['email' => 'foo', 'bar' => new Illuminate\Database\Query\Expression('bar')], 'id');
         $this->assertEquals(1, $result);
     }
 
@@ -700,7 +695,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('insert')
                 ->once()
-                ->with('insert into users (email) values (CURRENT TIMESTAMP)', [])
+                ->with('insert into users ("EMAIL") values (CURRENT TIMESTAMP)', [])
                 ->andReturn(true);
         $result = $builder->from('users')->insert(['email' => new Raw('CURRENT TIMESTAMP')]);
         $this->assertTrue($result);
@@ -712,7 +707,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('update')
                 ->once()
-                ->with('update users set email = ?, name = ? where id = ?', ['foo', 'bar', 1])
+                ->with('update users set "EMAIL" = ?, "NAME" = ? where "ID" = ?', ['foo', 'bar', 1])
                 ->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
@@ -724,7 +719,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('update')
                 ->once()
-                ->with('update users inner join orders on users.id = orders.user_id set email = ?, name = ? where users.id = ?',
+                ->with('update users inner join orders on users."ID" = orders."USER_ID" set "EMAIL" = ?, "NAME" = ? where users."ID" = ?',
                     ['foo', 'bar', 1])
                 ->andReturn(1);
         $result = $builder->from('users')
@@ -740,7 +735,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('update')
                 ->once()
-                ->with('update users set email = foo, name = ? where id = ?', ['bar', 1])
+                ->with('update users set "EMAIL" = foo, "NAME" = ? where "ID" = ?', ['bar', 1])
                 ->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->update(['email' => new Raw('foo'), 'name' => 'bar']);
         $this->assertEquals(1, $result);
@@ -752,7 +747,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('delete')
                 ->once()
-                ->with('delete from users where email = ?', ['foo'])
+                ->with('delete from users where "EMAIL" = ?', ['foo'])
                 ->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->delete();
         $this->assertEquals(1, $result);
@@ -761,7 +756,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('delete')
                 ->once()
-                ->with('delete from users where id = ?', [1])
+                ->with('delete from users where "ID" = ?', [1])
                 ->andReturn(1);
         $result = $builder->from('users')->delete(1);
         $this->assertEquals(1, $result);
@@ -787,7 +782,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', null);
-        $this->assertEquals('select * from users where foo is null', $builder->toSql());
+        $this->assertEquals('select * from users where "FOO" is null', $builder->toSql());
     }
 
     public function testDynamicWhere()
@@ -844,7 +839,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-        $this->assertEquals('select * from foo where bar = ? for update', $builder->toSql());
+        $this->assertEquals('select * from foo where "BAR" = ? for update', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -861,7 +856,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-20');
-        $this->assertEquals('select * from users where trunc(created_at) = ?', $builder->toSql());
+        $this->assertEquals('select * from users where trunc("CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => '2015-12-20'], $builder->getBindings());
     }
 
@@ -869,7 +864,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 20);
-        $this->assertEquals('select * from users where extract (day from created_at) = ?', $builder->toSql());
+        $this->assertEquals('select * from users where extract (day from "CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => 20], $builder->getBindings());
     }
 
@@ -877,7 +872,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 12);
-        $this->assertEquals('select * from users where extract (month from created_at) = ?', $builder->toSql());
+        $this->assertEquals('select * from users where extract (month from "CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => 12], $builder->getBindings());
     }
 
@@ -885,7 +880,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2015);
-        $this->assertEquals('select * from users where extract (year from created_at) = ?', $builder->toSql());
+        $this->assertEquals('select * from users where extract (year from "CREATED_AT") = ?', $builder->toSql());
         $this->assertEquals([0 => 2015], $builder->getBindings());
     }
 
@@ -984,7 +979,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->orderBy('id', 'desc');
-        $this->assertEquals('select * from users where id = ? union select * from users where id = ? order by id desc',
+        $this->assertEquals('select * from users where "ID" = ? union select * from users where "ID" = ? order by "ID" desc',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }


### PR DESCRIPTION
This PR will:
- Implement wrapping of column name.
- Implement wrapping of schema and table name.
## Important!

This PR might be a **BREAKING CHANGE** to some users in a sense that this will force the proper use of `DB::raw()` on complex SQLs which was previously allowed by the package.

Example breaking code that used to work before this patch:

``` php
$q = DB::table('users')->select('min(id)')->first();
```

The proper way should be:

``` php
$q = DB::table('users')->select(DB::raw('min(id)'))->first();
```
