### PR TITLE
Allow update of sessionVars from config

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -65,6 +65,10 @@ class Oci8ServiceProvider extends ServiceProvider
             if (isset($config['schema'])) {
                 $sessionVars['CURRENT_SCHEMA'] = $config['schema'];
             }
+            
+            if (isset($config['session'])) {
+                $sessionVars = array_merge($sessionVars, $config['session']);
+            }
 
             $db->setSessionVars($sessionVars);
 


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->

I needed a way to update sessionVars without touching the Service Provider file. My goal was to set : 

```
// in database.php or oracle.php add :
'session'  => [
        'NLS_COMP'                =>  'LINGUISTIC',
        'NLS_SORT'                =>  'BINARY_CI'
],
```
 In order to get comparison and sorting right. But the SessionVars array only lives in the Service Provider and there was no way to extend it globally.