### PR TITLE
[5.3] When updating OracleEloquent, pass save options through.

### DIFF
--- a/src/Oci8/Eloquent/OracleEloquent.php
+++ b/src/Oci8/Eloquent/OracleEloquent.php
@@ -78,7 +78,7 @@ class OracleEloquent extends Model
             return $this->newQuery()->update($attributes);
         }
 
-        return $this->fill($attributes)->save();
+        return $this->fill($attributes)->save($options);
     }
 
     /**


### PR DESCRIPTION
Minor change. When updating an OracleEloquent, pass the save options through the save function.
