### PR TITLE
[5.5] Use upper case column name for reserved words.

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -203,7 +203,7 @@ class OracleGrammar extends Grammar
             return $value;
         }
 
-        $value = $this->isReserved($value) ? Str::lower($value) : Str::upper($value);
+        $value = Str::upper($value);
 
         return '"' . str_replace('"', '""', $value) . '"';
     }

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -31,7 +31,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('exists', 'drop', 'group')->from('users');
-        $this->assertEquals('select "exists", "drop", "group" from "USERS"', $builder->toSql());
+        $this->assertEquals('select "EXISTS", "DROP", "GROUP" from "USERS"', $builder->toSql());
     }
 
     public function testAddingSelects()
@@ -74,14 +74,14 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('schema.users');
-        $this->assertEquals('select * from "schema"."USERS"', $builder->toSql());
+        $this->assertEquals('select * from "SCHEMA"."USERS"', $builder->toSql());
     }
 
     public function testBasicColumnWrappingReservedWords()
     {
         $builder = $this->getBuilder();
         $builder->select('order')->from('users');
-        $this->assertEquals('select "order" from "USERS"', $builder->toSql());
+        $this->assertEquals('select "ORDER" from "USERS"', $builder->toSql());
     }
 
     public function testBasicWheres()
@@ -96,7 +96,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('blob', '=', 1);
-        $this->assertEquals('select * from "USERS" where "blob" = ?', $builder->toSql());
+        $this->assertEquals('select * from "USERS" where "BLOB" = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -770,7 +770,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('delete')
                 ->once()
-                ->with('delete from "USERS" where "ID" = ?', [1])
+                ->with('delete from "USERS" where "USERS"."ID" = ?', [1])
                 ->andReturn(1);
         $result = $builder->from('users')->delete(1);
         $this->assertEquals(1, $result);


### PR DESCRIPTION
Fixes problems with Oracle reserved words resulting in columns not found because of being lower-cased

When a reserved word is lowercased, it won't match table columns that were not explicitly created with lowercase. Default is to treat them as uppercase if enclosed in double quotes. This would result in the following problem:

Error Code    : 904
Error Message : ORA-00904: "label": invalid identifier
Position      : 67
Statement     : insert into "TABLE" ("label") values (:p0) returning "ID" into :p1

Also fixed a broken unit test for deleting a record by ID, where laravel adds the table name to the where clause.

**As a note, I left the Str:upper there, but I do want to ask you about that. In my opinion I can't justify anything that forces either direction. I'd say it would be better to leave it as it was specified (so remove 
Yajra\Oci8\Query\Grammars\OracleGrammar:206 altogether.** 
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
