### PR TITLE
[5.4] Convert reserved words to lower case.

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Yajra\Oci8\OracleReservedWords;
 
 class OracleGrammar extends Grammar
@@ -741,7 +742,7 @@ class OracleGrammar extends Grammar
     protected function wrapValue($value)
     {
         if ($this->isReserved($value)) {
-            return parent::wrapValue($value);
+            return Str::lower(parent::wrapValue($value));
         }
 
         return $value !== '*' ? sprintf($this->wrapper, $value) : $value;

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -770,7 +770,7 @@ class Oci8QueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()
                 ->shouldReceive('delete')
                 ->once()
-                ->with('delete from "USERS" where "ID" = ?', [1])
+                ->with('delete from "USERS" where "USERS"."ID" = ?', [1])
                 ->andReturn(1);
         $result = $builder->from('users')->delete(1);
         $this->assertEquals(1, $result);


### PR DESCRIPTION
In relation to #262, reserved words should be forced to use lower case column name. 