### PR TITLE
Change getDoctrineConnection() to use a singleton

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -190,11 +190,14 @@ class Oci8Connection extends Connection
      */
     public function getDoctrineConnection()
     {
-        $driver = $this->getDoctrineDriver();
-
-        $data = ['pdo' => $this->getPdo(), 'user' => $this->getConfig('username')];
-
-        return new DoctrineConnection($data, $driver);
+        if (is_null($this->doctrineConnection)) {
+            $data = ['pdo' => $this->getPdo(), 'user' => $this->getConfig('username')];
+            $this->doctrineConnection = new DoctrineConnection(
+                $data, $this->getDoctrineDriver()
+            );
+        }
+        
+        return $this->doctrineConnection;
     }
 
     /**


### PR DESCRIPTION
Currently `$connection->getDoctrineConnection()` returns a new instance of `DoctrineConnection` on every call. It should instead use a singleton.
A related issue is [here](https://github.com/the-control-group/voyager/pull/1171). That issue is happening because a new instance of `DoctrinePlatform` is created on each call, so any added types will be lost.