### PR TITLE
[5.4] Fix missing table prefix when adding comment.

### DIFF
--- a/src/Oci8/Schema/Comment.php
+++ b/src/Oci8/Schema/Comment.php
@@ -88,7 +88,7 @@ class Comment extends Grammar
     private function commentColumn($table, $column, $comment)
     {
         $table = $this->wrapValue($table);
-
+        $table = $this->connection->getTablePrefix() . $table;
         $column = $this->wrapValue($column);
 
         $this->connection->statement("comment on column {$table}.{$column} is '{$comment}'");


### PR DESCRIPTION
Add table prefix to column comment.