### PR TITLE
[5.4] Extended configuration for parameter bindings

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -61,6 +61,7 @@ class Oci8Connection extends Connection
      * Set current schema.
      *
      * @param string $schema
+     *
      * @return $this
      */
     public function setSchema($schema)
@@ -77,6 +78,7 @@ class Oci8Connection extends Connection
      * Update oracle session variables.
      *
      * @param array $sessionVars
+     *
      * @return $this
      */
     public function setSessionVars(array $sessionVars)
@@ -90,7 +92,7 @@ class Oci8Connection extends Connection
             }
         }
         if ($vars) {
-            $sql = 'ALTER SESSION SET '.implode(' ', $vars);
+            $sql = 'ALTER SESSION SET ' . implode(' ', $vars);
             $this->statement($sql);
         }
 
@@ -111,6 +113,7 @@ class Oci8Connection extends Connection
      * Set sequence class.
      *
      * @param \Yajra\Oci8\Schema\Sequence $sequence
+     *
      * @return \Yajra\Oci8\Schema\Sequence
      */
     public function setSequence(Sequence $sequence)
@@ -132,6 +135,7 @@ class Oci8Connection extends Connection
      * Set oracle trigger class.
      *
      * @param \Yajra\Oci8\Schema\Trigger $trigger
+     *
      * @return \Yajra\Oci8\Schema\Trigger
      */
     public function setTrigger(Trigger $trigger)
@@ -157,6 +161,7 @@ class Oci8Connection extends Connection
      * Begin a fluent query against a database table.
      *
      * @param string $table
+     *
      * @return \Yajra\Oci8\Query\OracleBuilder
      */
     public function table($table)
@@ -172,6 +177,7 @@ class Oci8Connection extends Connection
      * Set oracle session date format.
      *
      * @param string $format
+     *
      * @return $this
      */
     public function setDateFormat($format = 'YYYY-MM-DD HH24:MI:SS')
@@ -221,6 +227,7 @@ class Oci8Connection extends Connection
      * @param array  $bindings (kvp array)
      * @param int    $returnType (PDO::PARAM_*)
      * @param int    $length
+     *
      * @return mixed $returnType
      */
     public function executeFunction($functionName, array $bindings = [], $returnType = PDO::PARAM_STR, $length = null)
@@ -246,6 +253,7 @@ class Oci8Connection extends Connection
      *
      * @param  string $procedureName
      * @param  array  $bindings
+     *
      * @return bool
      */
     public function executeProcedure($procedureName, array $bindings = [])
@@ -266,6 +274,7 @@ class Oci8Connection extends Connection
      * @param  string $procedureName
      * @param  array  $bindings
      * @param  string $cursorName
+     *
      * @return array
      */
     public function executeProcedureWithCursor($procedureName, array $bindings = [], $cursorName = ':cursor')
@@ -292,16 +301,17 @@ class Oci8Connection extends Connection
      * @param  string      $procedureName
      * @param  array       $bindings
      * @param  string|bool $cursor
+     *
      * @return string
      */
     public function createSqlFromProcedure($procedureName, array $bindings, $cursor = false)
     {
         $paramsString = implode(',', array_map(function ($param) {
-            return ':'.$param;
+            return ':' . $param;
         }, array_keys($bindings)));
 
         $prefix = count($bindings) ? ',' : '';
-        $cursor = $cursor ? $prefix.$cursor : null;
+        $cursor = $cursor ? $prefix . $cursor : null;
 
         return sprintf('begin %s(%s%s); end;', $procedureName, $paramsString, $cursor);
     }
@@ -312,6 +322,7 @@ class Oci8Connection extends Connection
      * @param  string      $procedureName
      * @param  array       $bindings
      * @param  string|bool $cursorName
+     *
      * @return PDOStatement
      */
     public function createStatementFromProcedure($procedureName, array $bindings, $cursorName = false)
@@ -331,7 +342,7 @@ class Oci8Connection extends Connection
      */
     public function createStatementFromFunction($functionName, array $bindings)
     {
-        $bindings = $bindings ? ':'.implode(', :', array_keys($bindings)) : '';
+        $bindings = $bindings ? ':' . implode(', :', array_keys($bindings)) : '';
 
         $sql = sprintf('begin :result := %s(%s); end;', $functionName, $bindings);
 
@@ -365,6 +376,7 @@ class Oci8Connection extends Connection
      * Set the table prefix and return the grammar.
      *
      * @param \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar|\Yajra\Oci8\Schema\Grammars\OracleGrammar $grammar
+     *
      * @return \Illuminate\Database\Grammar
      */
     public function withTablePrefix(Grammar $grammar)
@@ -376,6 +388,7 @@ class Oci8Connection extends Connection
      * Set the schema prefix and return the grammar.
      *
      * @param \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar|\Yajra\Oci8\Schema\Grammars\OracleGrammar $grammar
+     *
      * @return \Illuminate\Database\Grammar
      */
     public function withSchemaPrefix(Grammar $grammar)
@@ -427,16 +440,19 @@ class Oci8Connection extends Connection
     {
         foreach ($bindings as $key => &$binding) {
 
-            $type  = PDO::PARAM_STR;
-            $value = &$binding;
+            //defaults
+            $value  = &$binding;
+            $type   = PDO::PARAM_STR;
+            $length = null;
 
             // extended array syntax for bindings
             if (is_array($binding)) {
-                $value = &$binding['value'];
-                $type  = $binding['type'];
+                $value  = &$binding['value'];
+                $type   = array_key_exists('type', $binding) ? $binding['type'] : PDO::PARAM_STR;
+                $length = array_key_exists('length', $binding) ? $binding['length'] : null;
             }
 
-            $stmt->bindParam(':' . $key, $value, $type);
+            $stmt->bindParam(':' . $key, $value, $type, $length);
         }
 
         return $stmt;

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -415,7 +415,7 @@ class Oci8Connection extends Connection
     }
 
     /**
-     * Add bindings to statement
+     * Add bindings to statement.
      *
      * @param  array        $bindings
      * @param  PDOStatement $stmt

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -61,7 +61,6 @@ class Oci8Connection extends Connection
      * Set current schema.
      *
      * @param string $schema
-     *
      * @return $this
      */
     public function setSchema($schema)
@@ -78,7 +77,6 @@ class Oci8Connection extends Connection
      * Update oracle session variables.
      *
      * @param array $sessionVars
-     *
      * @return $this
      */
     public function setSessionVars(array $sessionVars)
@@ -113,7 +111,6 @@ class Oci8Connection extends Connection
      * Set sequence class.
      *
      * @param \Yajra\Oci8\Schema\Sequence $sequence
-     *
      * @return \Yajra\Oci8\Schema\Sequence
      */
     public function setSequence(Sequence $sequence)
@@ -135,7 +132,6 @@ class Oci8Connection extends Connection
      * Set oracle trigger class.
      *
      * @param \Yajra\Oci8\Schema\Trigger $trigger
-     *
      * @return \Yajra\Oci8\Schema\Trigger
      */
     public function setTrigger(Trigger $trigger)
@@ -161,7 +157,6 @@ class Oci8Connection extends Connection
      * Begin a fluent query against a database table.
      *
      * @param string $table
-     *
      * @return \Yajra\Oci8\Query\OracleBuilder
      */
     public function table($table)
@@ -177,7 +172,6 @@ class Oci8Connection extends Connection
      * Set oracle session date format.
      *
      * @param string $format
-     *
      * @return $this
      */
     public function setDateFormat($format = 'YYYY-MM-DD HH24:MI:SS')
@@ -227,7 +221,6 @@ class Oci8Connection extends Connection
      * @param array  $bindings (kvp array)
      * @param int    $returnType (PDO::PARAM_*)
      * @param int    $length
-     *
      * @return mixed $returnType
      */
     public function executeFunction($functionName, array $bindings = [], $returnType = PDO::PARAM_STR, $length = null)
@@ -253,7 +246,6 @@ class Oci8Connection extends Connection
      *
      * @param  string $procedureName
      * @param  array  $bindings
-     *
      * @return bool
      */
     public function executeProcedure($procedureName, array $bindings = [])
@@ -274,7 +266,6 @@ class Oci8Connection extends Connection
      * @param  string $procedureName
      * @param  array  $bindings
      * @param  string $cursorName
-     *
      * @return array
      */
     public function executeProcedureWithCursor($procedureName, array $bindings = [], $cursorName = ':cursor')
@@ -301,7 +292,6 @@ class Oci8Connection extends Connection
      * @param  string      $procedureName
      * @param  array       $bindings
      * @param  string|bool $cursor
-     *
      * @return string
      */
     public function createSqlFromProcedure($procedureName, array $bindings, $cursor = false)
@@ -322,7 +312,6 @@ class Oci8Connection extends Connection
      * @param  string      $procedureName
      * @param  array       $bindings
      * @param  string|bool $cursorName
-     *
      * @return PDOStatement
      */
     public function createStatementFromProcedure($procedureName, array $bindings, $cursorName = false)
@@ -337,7 +326,6 @@ class Oci8Connection extends Connection
      *
      * @param string $functionName
      * @param array  $bindings
-     *
      * @return PDOStatement
      */
     public function createStatementFromFunction($functionName, array $bindings)
@@ -376,7 +364,6 @@ class Oci8Connection extends Connection
      * Set the table prefix and return the grammar.
      *
      * @param \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar|\Yajra\Oci8\Schema\Grammars\OracleGrammar $grammar
-     *
      * @return \Illuminate\Database\Grammar
      */
     public function withTablePrefix(Grammar $grammar)
@@ -433,7 +420,6 @@ class Oci8Connection extends Connection
      *
      * @param  array        $bindings
      * @param  PDOStatement $stmt
-     *
      * @return PDOStatement
      */
     public function addBindingsToStatement(PDOStatement $stmt, array $bindings)

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -375,7 +375,6 @@ class Oci8Connection extends Connection
      * Set the schema prefix and return the grammar.
      *
      * @param \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar|\Yajra\Oci8\Schema\Grammars\OracleGrammar $grammar
-     *
      * @return \Illuminate\Database\Grammar
      */
     public function withSchemaPrefix(Grammar $grammar)

--- a/tests/Functional/ProceduresAndFunctionsTest.php
+++ b/tests/Functional/ProceduresAndFunctionsTest.php
@@ -40,9 +40,6 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
 
         $connection->executeProcedure($procedureName, $bindings);
 
-        //unfortunately we need to cast here.. any better ideas?
-        $output = (int)$output;
-
         $this->assertSame($input * 2, $output);
     }
 
@@ -75,7 +72,7 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
 
         $connection->executeProcedure($procedureName, $bindings);
 
-        $this->assertSame($first.$last, $output);
+        $this->assertSame($first . $last, $output);
     }
 
     public function testRefCursorFromTable()

--- a/tests/Functional/ProceduresAndFunctionsTest.php
+++ b/tests/Functional/ProceduresAndFunctionsTest.php
@@ -27,18 +27,21 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
 
         $connection->getPdo()->exec($command);
 
-        $input  = 2;
+        $input  = 20;
         $output = 0;
 
         $bindings = [
             'p1' => $input,
-            'p2' => &$output,
+            'p2' => [
+                'value' => &$output,
+                'type'  => PDO::PARAM_INT
+            ]
         ];
 
         $connection->executeProcedure($procedureName, $bindings);
 
         //unfortunately we need to cast here.. any better ideas?
-        $output = (int) $output;
+        $output = (int)$output;
 
         $this->assertSame($input * 2, $output);
     }
@@ -72,7 +75,7 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
 
         $connection->executeProcedure($procedureName, $bindings);
 
-        $this->assertSame($first . $last, $output);
+        $this->assertSame($first.$last, $output);
     }
 
     public function testRefCursorFromTable()
@@ -137,7 +140,7 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
         $result = $connection->executeFunction($procedureName, $bindings);
 
         // we need to cast here b/c oracle returns strings
-        $result = (int) $result;
+        $result = (int)$result;
 
         $this->assertSame($first + 2, $result);
     }

--- a/tests/Functional/ProceduresAndFunctionsTest.php
+++ b/tests/Functional/ProceduresAndFunctionsTest.php
@@ -34,7 +34,7 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
             'p1' => $input,
             'p2' => [
                 'value' => &$output,
-                'type'  => PDO::PARAM_INT
+                'type'  => PDO::PARAM_INT|PDO::PARAM_INPUT_OUTPUT
             ]
         ];
 
@@ -67,7 +67,10 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
         $bindings = [
             'p1' => $first,
             'p2' => $last,
-            'p3' => &$output,
+            'p3' => [
+                'value' => &$output,
+                'type'  => PDO::PARAM_STR|PDO::PARAM_INPUT_OUTPUT
+            ]
         ];
 
         $connection->executeProcedure($procedureName, $bindings);

--- a/tests/Functional/ProceduresAndFunctionsTest.php
+++ b/tests/Functional/ProceduresAndFunctionsTest.php
@@ -137,7 +137,7 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
         $result = $connection->executeFunction($procedureName, $bindings);
 
         // we need to cast here b/c oracle returns strings
-        $result = (int)$result;
+        $result = (int) $result;
 
         $this->assertSame($first + 2, $result);
     }

--- a/tests/Functional/ProceduresAndFunctionsTest.php
+++ b/tests/Functional/ProceduresAndFunctionsTest.php
@@ -34,8 +34,8 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
             'p1' => $input,
             'p2' => [
                 'value' => &$output,
-                'type'  => PDO::PARAM_INT|PDO::PARAM_INPUT_OUTPUT
-            ]
+                'type'  => PDO::PARAM_INT|PDO::PARAM_INPUT_OUTPUT,
+            ],
         ];
 
         $connection->executeProcedure($procedureName, $bindings);
@@ -69,8 +69,8 @@ class ProceduresAndFunctionsTest extends PHPUnit_Framework_TestCase
             'p2' => $last,
             'p3' => [
                 'value' => &$output,
-                'type'  => PDO::PARAM_STR|PDO::PARAM_INPUT_OUTPUT
-            ]
+                'type'  => PDO::PARAM_STR|PDO::PARAM_INPUT_OUTPUT,
+            ],
         ];
 
         $connection->executeProcedure($procedureName, $bindings);


### PR DESCRIPTION
This PR adds ability to specifiy parameter binding types like this one:

Fixes https://github.com/yajra/laravel-oci8/issues/337
```

        $input  = 20;
        $output = 0;

        $bindings = [
            'p1' => $input,
            'p2' => [
                'value' => &$output,
                'type'  => PDO::PARAM_INT
            ]
        ];

        $connection->executeProcedure($procedureName, $bindings);
```
see tests for more info.  this is a backwards compatible change!

cheers max