### PR TITLE
[5.5] Use uppercase for reserved words.

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -775,7 +775,7 @@ class OracleGrammar extends Grammar
     protected function wrapValue($value)
     {
         if ($this->isReserved($value)) {
-            return Str::lower(parent::wrapValue($value));
+            return Str::upper(parent::wrapValue($value));
         }
 
         return $value !== '*' ? sprintf($this->wrapper, $value) : $value;

--- a/tests/Oci8SchemaGrammarTest.php
+++ b/tests/Oci8SchemaGrammarTest.php
@@ -49,7 +49,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table users ( id number(10,0) not null, "group" varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table users ( id number(10,0) not null, "GROUP" varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
             $statements[0]);
     }
 


### PR DESCRIPTION
Fix #350.
