### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "yajra/laravel-pdo-via-oci8": "^1.3.1"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9.4",
+        "mockery/mockery": "~1.0",
         "scrutinizer/ocular": "~1.1",
         "phpunit/phpunit": "~6.0"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`~1.0`](https://github.com/mockery/mockery/releases/tag/1.0).