### PR TITLE
[5.2] Fix whereNotIn query clause.

### DIFF
--- a/src/Oci8/Query/OracleBuilder.php
+++ b/src/Oci8/Query/OracleBuilder.php
@@ -92,12 +92,10 @@ class OracleBuilder extends Builder
         if (count($values) > 1000) {
             $chunks = array_chunk($values, 1000);
 
-            return $this->where(function ($query) use ($column, $chunks, $type) {
-                $firstIteration = true;
+            return $this->where(function ($query) use ($not, $column, $chunks, $type) {
                 foreach ($chunks as $ch) {
-                    $sqlClause = $firstIteration ? 'where' . $type : 'orWhere' . $type;
+                    $sqlClause = $not ? 'where' . $type : 'orWhere' . $type;
                     $query->$sqlClause($column, $ch);
-                    $firstIteration = false;
                 }
 
             }, null, null, $boolean);


### PR DESCRIPTION
Fix whereNotIn query clause where `orWhere` query is being generated. Same patch implemented on the latest versions.