### PR TITLE
Fix issue #413 - Binding issue.

### DIFF
--- a/src/Oci8/Schema/Sequence.php
+++ b/src/Oci8/Schema/Sequence.php
@@ -39,12 +39,11 @@ class Sequence
 
         $nocache = $nocache ? 'nocache' : '';
 
-        $max = $max ? " maxvalue {$max}" : "";
+        $max = $max ? " maxvalue {$max}" : '';
 
         $sequence_stmt = "create sequence {$name} minvalue {$min} {$max} start with {$start} increment by {$increment} {$nocache}";
 
         return $this->connection->statement($sequence_stmt);
-
     }
 
     /**

--- a/tests/Functional/ProceduresAndFunctionsTest.php
+++ b/tests/Functional/ProceduresAndFunctionsTest.php
@@ -2,7 +2,6 @@
 
 use Yajra\Oci8\Oci8Connection;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Schema\Blueprint;
 use Yajra\Oci8\Connectors\OracleConnector;
 use Illuminate\Database\Capsule\Manager as Capsule;
 


### PR DESCRIPTION
The value of maxlength in oci-bind-by-name maybe -1 or another but not null.
this condition cause ORA 01460 but not in all versione of oci8. (http://php.net/manual/en/function.oci-bind-by-name.php)

please fix this error in method "addBindingsToStatement".
You must set $length = -1 instead of $length = null at line 435.

Thanks.