### PR TITLE
[5.7] Facilitate wallet support.

### DIFF
--- a/src/Oci8/Connectors/OracleConnector.php
+++ b/src/Oci8/Connectors/OracleConnector.php
@@ -32,6 +32,12 @@ class OracleConnector extends Connector implements ConnectorInterface
 
         $options = $this->getOptions($config);
 
+        if (array_get($options, 'session_mode') === OCI_CRED_EXT) {
+            // External connections can only be used with user / and an empty password
+            $config['username'] = '/';
+            $config['password'] = null;
+        }
+
         $connection = $this->createConnection($tns, $config, $options);
 
         return $connection;


### PR DESCRIPTION
This PR works in tandem with my other one (https://github.com/yajra/pdo-via-oci8/pull/61)

It sets the correct username / password in the connection details when using external credentials (this only works if a username '`/`' is used with an empty password)

Note: obviously this is not required to enable wallet support (only the one from `pdo-via-oci8` is), but it will save you having to specify it and possibly having to look through the docs to figure out why things don't work :) 