### PR TITLE
[5.7] Fix #485 - Preventing ORA-00933 when using fromSub method.

### DIFF
--- a/src/Oci8/Query/OracleBuilder.php
+++ b/src/Oci8/Query/OracleBuilder.php
@@ -105,4 +105,20 @@ class OracleBuilder extends Builder
 
         return $this->connection->select($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
     }
+
+    /**
+     * Makes "from" fetch from a subquery.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  string  $as
+     * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function fromSub($query, $as)
+    {
+        list($query, $bindings) = $this->createSub($query);
+
+        return $this->fromRaw('('.$query.') '.$this->grammar->wrap($as), $bindings);
+    }
 }


### PR DESCRIPTION
This PR fixes the #485 issue with new method `fromSub` in Query Builder class
Needs to be merged in 5.6+ versions