### PR TITLE
[5.8] Fix stripping of AS from table name.

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -186,7 +186,7 @@ class OracleGrammar extends Grammar
         }
 
         if (strpos(strtolower($table), ' as ') !== false) {
-            $table = str_replace(' as ', ' ', $table);
+            $table = str_replace(' as ', ' ', strtolower($table));
         }
 
         $tableName = $this->wrap($this->tablePrefix . $table, true);


### PR DESCRIPTION
Fix table alias when using capital `AS` on query.