### PR TITLE
[6.0] Laravel 6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-    - php: 7.1
-      env: setup=lowest
     - php: 7.2
     - php: 7.2
-      env: setup=lowest
+      env: SETUP=lowest
+    - php: 7.3
+    - php: 7.3
+      env: SETUP=lowest
+    - php: 7.4snapshot
+    - php: 7.4snapshot
+      env: SETUP=lowest
 
 sudo: required
 dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-oci8": ">=2.0.0",
-        "illuminate/support": "5.8.*",
-        "illuminate/auth": "5.8.*",
-        "illuminate/database": "5.8.*",
-        "yajra/laravel-pdo-via-oci8": "^1.3.1"
+        "ext-pdo": "*",
+        "illuminate/support": "^6.0",
+        "illuminate/database": "^6.0",
+        "yajra/laravel-pdo-via-oci8": "^2.0"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0",
+        "mockery/mockery": "^1.2.3",
         "scrutinizer/ocular": "~1.1",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "^8.3"
     },
     "autoload": {
         "files": [
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-          "dev-master": "5.8-dev"
+          "dev-master": "6.0-dev"
         },
         "laravel": {
             "providers": [

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -344,19 +344,6 @@ class Oci8Connection extends Connection
     }
 
     /**
-     * Bind values to their parameters in the given statement.
-     *
-     * @param PDOStatement $statement
-     * @param array        $bindings
-     */
-    public function bindValues($statement, $bindings)
-    {
-        foreach ($bindings as $key => $value) {
-            $statement->bindParam($key, $bindings[$key]);
-        }
-    }
-
-    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -160,18 +160,15 @@ class Oci8Connection extends Connection
     }
 
     /**
-     * Begin a fluent query against a database table.
+     * Get a new query builder instance.
      *
-     * @param string $table
-     * @return \Yajra\Oci8\Query\OracleBuilder
+     * @return \Illuminate\Database\Query\Builder
      */
-    public function table($table)
+    public function query()
     {
-        $processor = $this->getPostProcessor();
-
-        $query = new QueryBuilder($this, $this->getQueryGrammar(), $processor);
-
-        return $query->from($table);
+        return new QueryBuilder(
+            $this, $this->getQueryGrammar(), $this->getPostProcessor()
+        );
     }
 
     /**

--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -22,7 +22,7 @@ class OracleProcessor extends Processor
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
         $id        = 0;
-        $parameter = 0;
+        $parameter = 1;
         $statement = $this->prepareStatement($query, $sql);
         $values    = $this->incrementBySequence($values, $sequence);
         $parameter = $this->bindValues($values, $statement, $parameter);

--- a/tests/Oci8ConnectionTest.php
+++ b/tests/Oci8ConnectionTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseConnectionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Oci8ConnectorTest.php
+++ b/tests/Oci8ConnectorTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseConnectorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -900,12 +900,13 @@ class Oci8QueryBuilderTest extends TestCase
         $this->assertCount(2, $builder->wheres);
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
     {
+        $this->expectException(BadMethodCallException::class);
+
         $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturn([]);
 
         $builder->noValidMethodHere();
     }

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -169,7 +169,7 @@ class Oci8QueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ?',
+        $this->assertSame('(select * from "USERS" where "ID" = ?) union (select * from "USERS" where "ID" = ?)',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
@@ -179,7 +179,7 @@ class Oci8QueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from "USERS" where "ID" = ? union all select * from "USERS" where "ID" = ?',
+        $this->assertEquals('(select * from "USERS" where "ID" = ?) union all (select * from "USERS" where "ID" = ?)',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
@@ -190,7 +190,7 @@ class Oci8QueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ?',
+        $this->assertEquals('(select * from "USERS" where "ID" = ?) union (select * from "USERS" where "ID" = ?) union (select * from "USERS" where "ID" = ?)',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
@@ -201,7 +201,7 @@ class Oci8QueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('select * from "USERS" where "ID" = ? union all select * from "USERS" where "ID" = ? union all select * from "USERS" where "ID" = ?',
+        $this->assertEquals('(select * from "USERS" where "ID" = ?) union all (select * from "USERS" where "ID" = ?) union all (select * from "USERS" where "ID" = ?)',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
@@ -307,7 +307,8 @@ class Oci8QueryBuilderTest extends TestCase
         $connection = $builder->getConnection();
         $connection->shouldReceive('getConfig')->andReturn('');
         $builder->select('*')->from('users')->offset(10);
-        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" >= 11', $builder->toSql());
+        $this->assertEquals('select t2.* from ( select rownum AS "rn", t1.* from (select * from "USERS") t1 ) t2 where t2."rn" >= 11',
+            $builder->toSql());
     }
 
     public function testLimitsAndOffsets()
@@ -1081,7 +1082,7 @@ class Oci8QueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->orderBy('id', 'desc');
-        $this->assertEquals('select * from "USERS" where "ID" = ? union select * from "USERS" where "ID" = ? order by "ID" desc',
+        $this->assertEquals('(select * from "USERS" where "ID" = ?) union (select * from "USERS" where "ID" = ?) order by "ID" desc',
             $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }

--- a/tests/Oci8QueryBuilderTest.php
+++ b/tests/Oci8QueryBuilderTest.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Query\Expression as Raw;
 
 class Oci8QueryBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/Oci8SchemaGrammarTest.php
+++ b/tests/Oci8SchemaGrammarTest.php
@@ -6,7 +6,7 @@ use Yajra\Oci8\Schema\OracleBlueprint as Blueprint;
 
 class Oci8SchemaGrammarTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/OracleEloquentTest.php
+++ b/tests/OracleEloquentTest.php
@@ -23,7 +23,7 @@ class OracleEloquentTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -6,7 +6,7 @@ use Yajra\Oci8\Schema\Sequence;
 
 class SequenceTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }


### PR DESCRIPTION
- Add support for Laravel 6.
- Use bindValues from base Connection.
- Fix in relation to https://github.com/yajra/pdo-via-oci8/pull/63.
- Fix #521. 

## IMPORTANT

~~This PR relies on https://github.com/yajra/pdo-via-oci8/pull/66.~~
This PR relies on https://github.com/yajra/pdo-via-oci8/pull/67.