### PR TITLE
[5.8] Added illuminate/auth as dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^7.1.3",
         "ext-oci8": ">=2.0.0",
         "illuminate/support": "5.8.*",
+        "illuminate/auth": "5.8.*",
         "illuminate/database": "5.8.*",
         "yajra/laravel-pdo-via-oci8": "^1.3.1"
     },

--- a/src/Oci8/Connectors/OracleConnector.php
+++ b/src/Oci8/Connectors/OracleConnector.php
@@ -4,6 +4,7 @@ namespace Yajra\Oci8\Connectors;
 
 use PDO;
 use Yajra\Pdo\Oci8;
+use Illuminate\Support\Arr;
 use Illuminate\Database\Connectors\Connector;
 use Illuminate\Database\Connectors\ConnectorInterface;
 
@@ -32,7 +33,7 @@ class OracleConnector extends Connector implements ConnectorInterface
 
         $options = $this->getOptions($config);
 
-        if (array_get($options, 'session_mode') === OCI_CRED_EXT) {
+        if (Arr::get($options, 'session_mode') === OCI_CRED_EXT) {
             // External connections can only be used with user / and an empty password
             $config['username'] = '/';
             $config['password'] = null;


### PR DESCRIPTION
Package throws error Class auth not found when running in Laravel Zero CLI framework which does not include auth component.

Found issue to be missing explicit requirement for illuminate/auth in composer.json, which happens to be loaded by default in full laravel framework

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
