### PR TITLE
[6.0] Allow custom sequence name on model nextValue.

### DIFF
--- a/src/Oci8/Eloquent/OracleEloquent.php
+++ b/src/Oci8/Eloquent/OracleEloquent.php
@@ -35,15 +35,18 @@ class OracleEloquent extends Model
     /**
      * Get next value of the model sequence.
      *
+     * @param  null|string $sequence
      * @return int
      */
-    public static function nextValue()
+    public static function nextValue($sequence = null)
     {
         $instance = new static;
 
+        $sequence = $sequence ?? $instance->getSequenceName();
+
         return $instance->getConnection()
                         ->getSequence()
-                        ->nextValue($instance->getSequenceName());
+                        ->nextValue($sequence);
     }
 
     /**


### PR DESCRIPTION
This will add a direct method to fetch the model's next sequence value.

## Example
```php
class User extends OracleEloquent
{
   public $incrementing = false;
   protected $sequence = 'user_id_seq';
}

$user = new User;
$user->id = User::nextValue();
$user->save();

// fetch next value from another sequence.
$user = new User;
$user->id = User::nextValue('user_seq');
$user->save();

````