### PR TITLE
[6.0] Fix whereInRaw and whereNotInRaw Grammar.

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -553,6 +553,6 @@ class OracleGrammar extends Grammar
             $i++;
         }
 
-        return $whereClause;
+        return '(' . $whereClause . ')';
     }
 }

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -494,4 +494,65 @@ class OracleGrammar extends Grammar
 
         return "extract ($type from {$this->wrap($where['column'])}) {$where['operator']} $value";
     }
+
+    /**
+     * Compile a "where not in raw" clause.
+     *
+     * For safety, whereIntegerInRaw ensures this method is only used with integer values.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotInRaw(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            if (is_array($where['values']) && count($where['values']) > 1000) {
+                return $this->resolveClause($where['column'], $where['values'], 'not in');
+            } else {
+                return $this->wrap($where['column']).' not in ('.implode(', ', $where['values']).')';
+            }
+        }
+
+        return '1 = 1';
+    }
+
+    /**
+     * Compile a "where in raw" clause.
+     *
+     * For safety, whereIntegerInRaw ensures this method is only used with integer values.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereInRaw(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            if (is_array($where['values']) && count($where['values']) > 1000) {
+                return $this->resolveClause($where['column'], $where['values'], 'in');
+            } else {
+                return $this->wrap($where['column']).' in ('.implode(', ', $where['values']).')';
+            }
+        }
+
+        return '0 = 1';
+    }
+
+    private function resolveClause($column, $values, $type)
+    {
+        $chunks = array_chunk($values, 1000);
+        $whereClause = '';
+        $i=0;
+        $type = $this->wrap($column) . ' '.$type.' ';
+        foreach ($chunks as $ch) {
+            if ($i > 0) {
+                $type = ' or '. $this->wrap($column) . ' ' . $type . ' ';
+            }
+            $whereClause  .= $type . '('.implode(', ', $ch).')';
+            $i++;
+        }
+
+        return $whereClause;
+    }
 }


### PR DESCRIPTION
With this commit you can make an eloquent query with a relationship on a table with more than 1000 results. 
Extending the model to OracleEloquent doesn't work because does not contamplate this case.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
