### PR TITLE
Fix bug from pull request #532

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -547,7 +547,7 @@ class OracleGrammar extends Grammar
         $type = $this->wrap($column) . ' '.$type.' ';
         foreach ($chunks as $ch) {
             if ($i > 0) {
-                $type = ' or '. $this->wrap($column) . ' ' . $type . ' ';
+                $type = ' or ' . $type . ' ';
             }
             $whereClause  .= $type . '('.implode(', ', $ch).')';
             $i++;


### PR DESCRIPTION
Testing I saw this bug. It puts something like this in the query:

`" or "table"."column" "table"."column" in  "`