### PR TITLE
WIP: Fix #542, make ORA_MAX_NAME_LEN configurable via env.

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -376,8 +376,11 @@ class OracleGrammar extends Grammar
      */
     private function dropConstraint(Blueprint $blueprint, Fluent $command, $type)
     {
-        $table = $this->wrapTable($blueprint);
-        $index = substr($command->index, 0, 30);
+        $table  = $this->wrapTable($blueprint);
+
+        $max_length = env('ORA_MAX_NAME_LEN', 30);
+
+        $index  = substr($command->index, 0, $max_length);
 
         if ($type === 'index') {
             return "drop index {$index}";

--- a/src/Oci8/Schema/OracleAutoIncrementHelper.php
+++ b/src/Oci8/Schema/OracleAutoIncrementHelper.php
@@ -93,8 +93,9 @@ class OracleAutoIncrementHelper
      */
     private function createObjectName($prefix, $table, $col, $type)
     {
-        // max object name length is 30 chars
-        return substr($prefix . $table . '_' . $col . '_' . $type, 0, 30);
+        $max_length = env('ORA_MAX_NAME_LEN', 30);
+
+        return substr($prefix . $table . '_' . $col . '_' . $type, 0, $max_length);
     }
 
     /**

--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -58,8 +58,8 @@ class OracleBlueprint extends Blueprint
 
         $index = str_replace(['-', '.'], '_', $index);
 
-        //shorten the name if it is longer than 30 chars
-        while (strlen($index) > 30) {
+        $max_length = env('ORA_MAX_NAME_LEN', 30);
+        while (strlen($index) > $max_length) {
             $parts = explode('_', $index);
 
             for ($i = 0; $i < count($parts); $i++) {


### PR DESCRIPTION
- Fix #542.
- Make `ORA_MAX_NAME_LEN` configurable via env.

## TODO

1. Fix tests.
2. Fetch ORA_MAX_NAME_LEN from config instead of env.