### PR TITLE
Fix pagination aggregate count.

### DIFF
--- a/src/Oci8/Query/OracleBuilder.php
+++ b/src/Oci8/Query/OracleBuilder.php
@@ -8,6 +8,30 @@ use Illuminate\Contracts\Support\Arrayable;
 class OracleBuilder extends Builder
 {
     /**
+     * Get the count of the total records for the paginator.
+     *
+     * @param  array  $columns
+     * @return int
+     */
+    public function getCountForPagination($columns = ['*'])
+    {
+        $results = $this->runPaginationCountQuery($columns);
+
+        // Once we have run the pagination count query, we will get the resulting count and
+        // take into account what type of query it was. When there is a group by we will
+        // just return the count of the entire results set since that will be correct.
+        if (isset($this->groups)) {
+            return count($results);
+        } elseif (! isset($results[0])) {
+            return 0;
+        } elseif (is_object($results[0])) {
+            return (int) (property_exists($results[0], 'AGGREGATE') ? $results[0]->AGGREGATE : $results[0]->aggregate);   // to solve the Oracle issue: auto-convert field to uppercase
+        }
+
+        return (int) array_change_key_case((array) $results[0])['aggregate'];
+    }
+
+    /**
      * Insert a new record and get the value of the primary key.
      *
      * @param  array $values


### PR DESCRIPTION
I find a a issue that Laravel `paginate` won't work with Oracle connections because of its naming conventions, and it print the message _`Undefined property: stdClass::$aggregate`_.

The Oracle statement _`SELECT COUNT(1) AS aggregate FROM TABLE`_, for instance, will return a column named **`AGGREGATE`**.

Unless the column name is enclosed within double quotes, such as _`SELECT COUNT(1) AS "aggregate" FROM TABLE`_.

Since the `aggregate` field will be converted to `AGGREGATE` in Oracle connections, I think we should also check whether `AGGREGATE` property exists.

Specifically, this issue would happen if set [`options' => [ PDO::ATTR_CASE => PDO::CASE_NATURAL ]`](https://github.com/yajra/laravel-oci8/issues/105#issuecomment-157610358) or  `options' => [ PDO::ATTR_CASE => PDO::CASE_UPPER ]`.

And I also [make a PR to Laravel Framework](https://github.com/laravel/framework/pull/32372), but it seems as if they don't accept it.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
