### PR TITLE
[8.x] Enable oracle case insensitive searches.

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -60,6 +60,8 @@ class Oci8ServiceProvider extends ServiceProvider
                 'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
                 'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
                 'NLS_NUMERIC_CHARACTERS'  => '.,',
+                'NLS_COMP'                => 'LINGUISTIC',
+                'NLS_SORT'                => 'BINARY_CI',
             ];
 
             // Like Postgres, Oracle allows the concept of "schema"


### PR DESCRIPTION
- Fix database presence validation issue (unique, exists, etc).
- Removes the dependency on OracleUserProvider.

Ref: http://www.dba-oracle.com/t_case_insensitive_indexes_searches.htm

To enable on lower versions, you can use the following code:

```php
class AppServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        DB::setSessionVars([
            'NLS_COMP' => 'LINGUISTIC',
            'NLS_SORT' => 'BINARY_CI',
        ]);
    }
}
```