### PR TITLE
[8.x][Security] Implement case insensitive function-based unique index.

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -266,7 +266,15 @@ class OracleGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return 'alter table ' . $this->wrapTable($blueprint) . " add constraint {$command->index} unique ( " . $this->columnize($command->columns) . ' )';
+        $columns =  array_map(function($column) {
+            $column = $this->wrap($column);
+
+            return "lower({$column})";
+        }, $command->columns);
+
+        $columns = implode(', ', $columns);
+
+        return sprintf('create unique index %s on %s (%s)', $command->index, $this->wrapTable($blueprint), $columns);
     }
 
     /**

--- a/tests/Oci8SchemaGrammarTest.php
+++ b/tests/Oci8SchemaGrammarTest.php
@@ -438,7 +438,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add constraint bar unique ( foo )', $statements[0]);
+        $this->assertEquals('create unique index bar on users (lower(foo))', $statements[0]);
     }
 
     public function testAddingDefinedUniqueKeyWithPrefix()
@@ -453,7 +453,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users add constraint bar unique ( foo )', $statements[0]);
+        $this->assertEquals('create unique index bar on prefix_users (lower(foo))', $statements[0]);
     }
 
     public function testAddingGeneratedUniqueKeyWithPrefix()
@@ -468,7 +468,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users add constraint prefix_users_foo_uk unique ( foo )',
+        $this->assertEquals('create unique index prefix_users_foo_uk on prefix_users (lower(foo))',
             $statements[0]);
     }
 


### PR DESCRIPTION
A security patch for unique constraint to enforce case insensitive matching:

Example:

## Before PR

Both users will be inserted without throwing a constraint error.

```php
users: email (unique)

User::create(['email' => 'admin@example.com']);
User::create(['email' => 'Admin@example.com']);
```

## After PR

```php
User::create(['email' => 'admin@example.com']);
User::create(['email' => 'Admin@example.com']);
```

Error Message : ORA-00001: unique constraint (SCHEMA.USERS_EMAIL_UK) violated


## NOTE

This patch only works on projects with fresh migrations. For existing projects, you need to create the unique index manually.