### PR TITLE
[8.x] Fix Model::create() with guarded property.

### DIFF
--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -169,7 +169,7 @@ class OracleProcessor extends Processor
         $mapping = function ($r) {
             $r = (object) $r;
 
-            return $r->column_name;
+            return strtolower($r->column_name);
         };
 
         return array_map($mapping, $results);

--- a/tests/Functional/ModelTest.php
+++ b/tests/Functional/ModelTest.php
@@ -24,12 +24,10 @@ class ModelTest extends TestCase
     /** @test */
     public function it_can_insert_using_create_method()
     {
-        $params = [
+        $user = UserWithGuardedProperty::create([
             'name'  => 'Test',
             'email' => 'test@example.com',
-        ];
-
-        UserWithGuardedProperty::create($params);
+        ]);
 
         $this->assertDatabaseCount('users', 21);
     }

--- a/tests/Functional/ModelTest.php
+++ b/tests/Functional/ModelTest.php
@@ -6,7 +6,7 @@ use Yajra\Oci8\Tests\TestCase;
 use Yajra\Oci8\Tests\UserWithGuardedProperty;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
-class ModelTests extends TestCase
+class ModelTest extends TestCase
 {
     use DatabaseTransactions;
 

--- a/tests/Functional/ModelTest.php
+++ b/tests/Functional/ModelTest.php
@@ -13,22 +13,26 @@ class ModelTest extends TestCase
     /** @test */
     public function it_can_insert_by_setting_the_property()
     {
+        $count = UserWithGuardedProperty::count();
+
         $user        = new UserWithGuardedProperty;
         $user->name  = 'Test';
         $user->email = 'test@example.com';
         $user->save();
 
-        $this->assertDatabaseCount('users', 21);
+        $this->assertDatabaseCount('users', $count + 1);
     }
 
     /** @test */
     public function it_can_insert_using_create_method()
     {
-        $user = UserWithGuardedProperty::create([
+        $count = UserWithGuardedProperty::count();
+
+        UserWithGuardedProperty::create([
             'name'  => 'Test',
             'email' => 'test@example.com',
         ]);
 
-        $this->assertDatabaseCount('users', 21);
+        $this->assertDatabaseCount('users', $count + 1);
     }
 }

--- a/tests/Functional/ModelTests.php
+++ b/tests/Functional/ModelTests.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional;
+
+use Yajra\Oci8\Tests\TestCase;
+use Yajra\Oci8\Tests\UserWithGuardedProperty;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ModelTests extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_can_insert_by_setting_the_property()
+    {
+        $user        = new UserWithGuardedProperty;
+        $user->name  = 'Test';
+        $user->email = 'test@example.com';
+        $user->save();
+
+        $this->assertDatabaseCount('users', 21);
+    }
+
+    /** @test */
+    public function it_can_insert_using_create_method()
+    {
+        $params = [
+            'name'  => 'Test',
+            'email' => 'test@example.com',
+        ];
+
+        UserWithGuardedProperty::create($params);
+
+        $this->assertDatabaseCount('users', 21);
+    }
+}

--- a/tests/UserWithGuardedProperty.php
+++ b/tests/UserWithGuardedProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yajra\Oci8\Tests;
+
+class UserWithGuardedProperty extends User
+{
+    protected $table = 'users';
+
+    protected $guarded = ['id'];
+}


### PR DESCRIPTION
Fix #596