### PR TITLE
bugfix: Quote column name "id" so as to not affected by PDO::ATTR_CASE

### DIFF
--- a/src/Oci8/Schema/Sequence.php
+++ b/src/Oci8/Schema/Sequence.php
@@ -100,7 +100,7 @@ class Sequence
             return 0;
         }
 
-        return $this->connection->selectOne("SELECT $name.NEXTVAL as id FROM DUAL")->id;
+        return $this->connection->selectOne("SELECT $name.NEXTVAL as \"id\" FROM DUAL")->id;
     }
 
     /**
@@ -127,6 +127,6 @@ class Sequence
             return 0;
         }
 
-        return $this->connection->selectOne("select {$name}.currval as id from dual")->id;
+        return $this->connection->selectOne("select {$name}.currval as \"id\" from dual")->id;
     }
 }


### PR DESCRIPTION
When connections.options in database/config.php has attribute letter-case
settings like `PDO::ATTR_CASE => PDO::CASE_UPPER`, both of
nextValue/currentValue methods will fail retrieving values.

This is because they always expected lower-cased `id` property from stdClass
generated by `selectOne` method.

This patch will quote "id" in SQL as-statement so ensure returned
stdClass object has lower-cased `id` property.

See also:
    https://github.com/yajra/laravel-oci8/issues/105
    https://github.com/yajra/laravel-oci8/pull/570

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
