### PR TITLE
Added support for connection timeout

### DIFF
--- a/src/Oci8/Connectors/OracleConnector.php
+++ b/src/Oci8/Connectors/OracleConnector.php
@@ -146,7 +146,7 @@ class OracleConnector extends Connector implements ConnectorInterface
      */
     protected function setTNS(array $config)
     {
-        $config['tns'] = "(DESCRIPTION = (ADDRESS = (PROTOCOL = {$config['protocol']})(HOST = {$config['host']})(PORT = {$config['port']})) (CONNECT_DATA =({$config['service']})))";
+        $config['tns'] = "(DESCRIPTION = (CONNECT_TIMEOUT={$config['timeout']}) (ADDRESS = (PROTOCOL = {$config['protocol']})(HOST = {$config['host']})(PORT = {$config['port']})) (CONNECT_DATA =({$config['service']})))";
 
         return $config;
     }


### PR DESCRIPTION
<!--

I am submitting PR for https://github.com/yajra/laravel-oci8/issues/636. Support for connection timeout implemented (https://docs.oracle.com/database/121/NETRF/tnsnames.htm#NETRF666). oci_connect documentation(https://www.php.net/manual/en/function.oci-connect.php#refsect1-function.oci-connect-parameters) is referring to oracle, timeout is implemented as requested per oracle doc.

-->
