### PR TITLE
Fixing problem with limit and offset in oracle 11g

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -132,7 +132,7 @@ class OracleGrammar extends Grammar
     protected function compileRowConstraint($query)
     {
         $startValueDefault = $query->offset * $query->limit;
-        $start  = $startValueDefault + 1;
+        $start = $startValueDefault + 1;
         $finish = $startValueDefault + $query->limit;
 
         if ($query->limit == 1 && is_null($query->offset)) {

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -158,15 +158,15 @@ class OracleGrammar extends Grammar
         if ($query->limit == 1 && is_null($query->offset)) {
             return "select * from ({$sql}) where rownum {$constraint}";
         }
-
-        if (! is_null($query->limit && ! is_null($query->offset))) {
-            $start  = $query->offset + 1;
-            $finish = $query->offset + $query->limit;
-
-            return "select t2.* from ( select rownum AS \"rn\", t1.* from ({$sql}) t1 where rownum <= {$finish}) t2 where t2.\"rn\" >= {$start}";
-        }
-
-        return "select t2.* from ( select rownum AS \"rn\", t1.* from ({$sql}) t1 ) t2 where t2.\"rn\" {$constraint}";
+        
+        return "select
+                t2.*
+            from (
+                select rownum AS \"rn\", t1.* from ({$sql}) t1 
+            ) t2 
+            where 
+                t2.\"rn\" {$constraint}
+        ";
     }
 
     /**

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -131,8 +131,9 @@ class OracleGrammar extends Grammar
      */
     protected function compileRowConstraint($query)
     {
-        $start  = $query->offset + 1;
-        $finish = $query->offset + $query->limit;
+        $startValueDefault = $query->offset * $query->limit;
+        $start  = $startValueDefault + 1;
+        $finish = ($startValueDefault - 1) + $query->limit;
 
         if ($query->limit == 1 && is_null($query->offset)) {
             return '= 1';

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -133,7 +133,7 @@ class OracleGrammar extends Grammar
     {
         $startValueDefault = $query->offset * $query->limit;
         $start  = $startValueDefault + 1;
-        $finish = ($startValueDefault - 1) + $query->limit;
+        $finish = $startValueDefault + $query->limit;
 
         if ($query->limit == 1 && is_null($query->offset)) {
             return '= 1';


### PR DESCRIPTION
This PR fix the problem with limit and offset in oracle 11g using ``` between ``` in comparer ``` rn ```. Changing the calculus in ``` compileRowConstraint ```, the change try create pagination in query, eg: 

* ``` limit = 30```
* ``` offset (page) = 1```

The calculus create the sequence:
``` t2.rn between 1 and 30 ```

And, if used ``` offset (page) = 2``` will have

``` t2.rn between 31 and 60 ```

The math formula is:

``` 
start = offset * limit;
finish = start + limit;
```