### PR TITLE
Fixed checkMultipleHostDsn SERVICE_NAME using inconsistent database config bugs.

### DIFF
--- a/src/Oci8/Connectors/OracleConnector.php
+++ b/src/Oci8/Connectors/OracleConnector.php
@@ -24,7 +24,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Establish a database connection.
      *
-     * @param array $config
+     * @param  array  $config
      * @return PDO
      */
     public function connect(array $config)
@@ -47,7 +47,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Create a DSN string from a configuration.
      *
-     * @param  array $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)
@@ -69,7 +69,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Parse configurations.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     protected function parseConfig(array $config)
@@ -87,7 +87,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set host from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     protected function setHost(array $config)
@@ -100,7 +100,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set port from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     private function setPort(array $config)
@@ -113,7 +113,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set protocol from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     private function setProtocol(array $config)
@@ -126,7 +126,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set service id from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     protected function setServiceId(array $config)
@@ -141,7 +141,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set tns from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     protected function setTNS(array $config)
@@ -154,7 +154,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set charset from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     protected function setCharset(array $config)
@@ -169,7 +169,7 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Set DSN host from config.
      *
-     * @param array $config
+     * @param  array  $config
      * @return array
      */
     protected function checkMultipleHostDsn(array $config)
@@ -193,9 +193,9 @@ class OracleConnector extends Connector implements ConnectorInterface
     /**
      * Create a new PDO connection.
      *
-     * @param  string $tns
-     * @param  array $config
-     * @param  array $options
+     * @param  string  $tns
+     * @param  array  $config
+     * @param  array  $options
      * @return PDO
      */
     public function createConnection($tns, array $config, array $options)

--- a/src/Oci8/Connectors/OracleConnector.php
+++ b/src/Oci8/Connectors/OracleConnector.php
@@ -184,7 +184,7 @@ class OracleConnector extends Connector implements ConnectorInterface
             }
 
             // create a tns with multiple address connection
-            $config['tns'] = "(DESCRIPTION = {$address} (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = {$config['database']})))";
+            $config['tns'] = "(DESCRIPTION = {$address} (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) ({$config['service']})))";
         }
 
         return $config;

--- a/tests/Database/Oci8ConnectorTest.php
+++ b/tests/Database/Oci8ConnectorTest.php
@@ -77,23 +77,23 @@ class Oci8ConnectorTest extends TestCase
             [
                 '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = ORCL)))',
                 [
-                    'driver'   => 'oracle',
-                    'host'     => 'localhost, oracle.host',
-                    'port'     => '1234',
-                    'database' => 'ORCL',
-                    'tns'      => '',
+                    'driver'       => 'oracle',
+                    'host'         => 'localhost, oracle.host',
+                    'port'         => '1234',
+                    'service_name' => 'ORCL',
+                    'tns'          => '',
                 ],
             ],
             // multiple hosts with schema
             [
                 '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = ORCL)))',
                 [
-                    'driver'   => 'oracle',
-                    'host'     => 'localhost, oracle.host',
-                    'port'     => '1234',
-                    'database' => 'ORCL',
-                    'tns'      => '',
-                    'schema'   => 'users',
+                    'driver'       => 'oracle',
+                    'host'         => 'localhost, oracle.host',
+                    'port'         => '1234',
+                    'service_name' => 'ORCL',
+                    'tns'          => '',
+                    'schema'       => 'users',
                 ],
             ],
             // using config

--- a/tests/Database/Oci8ConnectorTest.php
+++ b/tests/Database/Oci8ConnectorTest.php
@@ -76,7 +76,7 @@ class Oci8ConnectorTest extends TestCase
         return [
             // multiple hosts SID
             [
-                '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (DATABASE = ORCL)))',
+                '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SID = ORCL)))',
                 [
                     'driver'       => 'oracle',
                     'host'         => 'localhost, oracle.host',
@@ -87,7 +87,7 @@ class Oci8ConnectorTest extends TestCase
             ],
             // multiple hosts SID with schema
             [
-                '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (DATABASE = ORCL)))',
+                '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SID = ORCL)))',
                 [
                     'driver'       => 'oracle',
                     'host'         => 'localhost, oracle.host',

--- a/tests/Database/Oci8ConnectorTest.php
+++ b/tests/Database/Oci8ConnectorTest.php
@@ -74,7 +74,30 @@ class Oci8ConnectorTest extends TestCase
     public function OracleConnectProvider()
     {
         return [
-            // multiple hosts
+            // multiple hosts SID
+            [
+                '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (DATABASE = ORCL)))',
+                [
+                    'driver'       => 'oracle',
+                    'host'         => 'localhost, oracle.host',
+                    'port'         => '1234',
+                    'database'     => 'ORCL',
+                    'tns'          => '',
+                ],
+            ],
+            // multiple hosts SID with schema
+            [
+                '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (DATABASE = ORCL)))',
+                [
+                    'driver'       => 'oracle',
+                    'host'         => 'localhost, oracle.host',
+                    'port'         => '1234',
+                    'database'     => 'ORCL',
+                    'tns'          => '',
+                    'schema'       => 'users',
+                ],
+            ],
+            // multiple hosts SERVICE_NAME
             [
                 '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = ORCL)))',
                 [
@@ -85,7 +108,7 @@ class Oci8ConnectorTest extends TestCase
                     'tns'          => '',
                 ],
             ],
-            // multiple hosts with schema
+            // multiple hosts SERVICE_NAME with schema
             [
                 '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1234))(ADDRESS = (PROTOCOL = TCP)(HOST = oracle.host)(PORT = 1234)) (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = ORCL)))',
                 [

--- a/tests/Database/Oci8ConnectorTest.php
+++ b/tests/Database/Oci8ConnectorTest.php
@@ -43,6 +43,7 @@ class Oci8ConnectorTest extends TestCase
 
     /**
      * @dataProvider OracleConnectProvider
+     *
      * @param $dsn
      * @param $config
      */


### PR DESCRIPTION
In the `checkMultipleHostDsn()` method, this project uses `SERVICE_NAME = {$config['database']}`, which differs from `setServiceId()`:

```php
protected function setServiceId(array $config)
{
    $config['service']   = empty($config['service_name'])
        ? $service_param = 'SID = ' . $config['database']
        : $service_param = 'SERVICE_NAME = ' . $config['service_name'];

    return $config;
}
```

To unify user experience and ease confusion over configuration, I propose to modify `checkMultipleHostDsn()` method, making CONNECT_DATA the same by using  `$config['service']`:

```php
$config['tns'] = "(DESCRIPTION = {$address} (LOAD_BALANCE = yes) (FAILOVER = on) (CONNECT_DATA = (SERVER = DEDICATED) ({$config['service']})))";
```