### PR TITLE
[9.x] Add Oci8Driver getName method

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,2 +1,1 @@
-php:
-  preset: laravel
+preset: laravel

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
         "yajra/laravel-pdo-via-oci8": "^3.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
+        "doctrine/dbal": "^3.3",
         "mockery/mockery": "^1.4.4",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5.8"
     },
     "autoload": {
@@ -49,7 +50,7 @@
         }
     },
     "scripts": {
-        "docker": "docker run -d -p 49160:22 -p 49161:1521 deepdiver/docker-oracle-xe-11g"
+        "docker": "docker run -d -p 49160:22 -p 1521:1521 deepdiver/docker-oracle-xe-11g"
     },
     "config": {
         "sort-packages": true

--- a/src/Oci8/PDO/Oci8Driver.php
+++ b/src/Oci8/PDO/Oci8Driver.php
@@ -8,4 +8,12 @@ use Illuminate\Database\PDO\Concerns\ConnectsToDatabase;
 class Oci8Driver extends AbstractOracleDriver
 {
     use ConnectsToDatabase;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'oci8';
+    }
 }

--- a/tests/Functional/SchemaTest.php
+++ b/tests/Functional/SchemaTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Yajra\Oci8\Tests\TestCase;
+
+class SchemaTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_can_get_column_type()
+    {
+        $type = Schema::getColumnType('users', 'name');
+
+        $this->assertEquals('string', $type);
+    }
+}


### PR DESCRIPTION
Fix https://github.com/yajra/laravel-oci8/issues/710
Fix Schema::getColumnType()
Add test for Schema::getColumnType()
