### PR TITLE
feat: make session variables configurable

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -58,7 +58,14 @@ class Oci8ServiceProvider extends ServiceProvider
             }
 
             // set oracle session variables
-            $sessionVars = config('database.connections.sessionVars');
+            $defaultSessionVars = [
+                'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
+                'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',
+                'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
+                'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
+                'NLS_NUMERIC_CHARACTERS'  => '.,',
+            ];
+            $sessionVars = config('database.connections.sessionVars', $defaultSessionVars);
 
             // Like Postgres, Oracle allows the concept of "schema"
             if (isset($config['schema'])) {

--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -58,7 +58,7 @@ class Oci8ServiceProvider extends ServiceProvider
             }
 
             // set oracle session variables
-            $sessionVars = config('oracle.sessionVars');
+            $sessionVars = config('database.connections.sessionVars');
 
             // Like Postgres, Oracle allows the concept of "schema"
             if (isset($config['schema'])) {

--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -58,13 +58,7 @@ class Oci8ServiceProvider extends ServiceProvider
             }
 
             // set oracle session variables
-            $sessionVars = [
-                'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
-                'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',
-                'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
-                'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
-                'NLS_NUMERIC_CHARACTERS'  => '.,',
-            ];
+            $sessionVars = config('oracle.sessionVars');
 
             // Like Postgres, Oracle allows the concept of "schema"
             if (isset($config['schema'])) {

--- a/src/config/oracle.php
+++ b/src/config/oracle.php
@@ -18,7 +18,6 @@ return [
         'load_balance'   => env('DB_LOAD_BALANCE', 'yes'),
         'dynamic'        => [],
     ],
-    
     'sessionVars' => [
         'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
         'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',

--- a/src/config/oracle.php
+++ b/src/config/oracle.php
@@ -18,4 +18,12 @@ return [
         'load_balance'   => env('DB_LOAD_BALANCE', 'yes'),
         'dynamic'        => [],
     ],
+    
+    'sessionVars' => [
+        'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
+        'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',
+        'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
+        'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
+        'NLS_NUMERIC_CHARACTERS'  => '.,',
+    ]
 ];


### PR DESCRIPTION
fix `not valid month` error with commented ``NLS_DATE_FORMAT``
```
'sessionVars' => [
        'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
//        'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',
        'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
        'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
        'NLS_NUMERIC_CHARACTERS'  => '.,',
    ]
```