### PR TITLE
feat: add random order on grammar

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -593,4 +593,15 @@ class OracleGrammar extends Grammar
 
         return $sql.' from ('.$this->compileSelect($query).') '.$this->wrapTable('temp_table');
     }
+
+    /**
+     * Compile the random statement into SQL.
+     *
+     * @param  string  $seed
+     * @return string
+     */
+    public function compileRandom($seed)
+    {
+        return 'DBMS_RANDOM.RANDOM';
+    }
 }

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3073,6 +3073,15 @@ class Oci8QueryBuilderTest extends TestCase
         $this->assertEquals([], $clone->getBindings());
     }
 
+    public function testRandomOrder()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'foo')->inRandomOrder();
+
+        $this->assertSame('select * from "USERS" where "EMAIL" = ? order by DBMS_RANDOM.RANDOM', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);


### PR DESCRIPTION
Overrides `compileRandom` main method to be able to call inRandomOrder on models.