### PR TITLE
fix: ORA-00969 when creating indexes

### DIFF
--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -75,7 +75,7 @@ class OracleBlueprint extends Blueprint
                 $index = implode('_', $parts);
             }
         } else {
-            $index = substr($this->table, 0, 10).'_comp_'.microtime(true);
+            $index = substr($this->table, 0, 10) . '_comp_' . str_replace('.', '_', microtime(true));
         }
 
         return $index;


### PR DESCRIPTION
Creating an index with a long name (> 30 characters) fails on our Oracle infrastructure with the following message:

```
ORA-00969: missing ON keyword

create unique index TABLENAME1_comp_1672411435.011 on PREFIX_TABLENAME1_XXXX (lower(COL1), lower(COL2), lower(COL3))
```
By replacing the dot (.) in the index name "TABLENAME1_comp_1672411435.011", it works again. It is what this patch does.

**System details**

- Ubuntu 20.04.5 LTS / Windows 10
- Oracle Database 12c Standard Edition Release 12.2.0.1.0 - 64bit Production
- PHP 8.0.26 / PHP 8.1.3
- Laravel Version 9.37
- Laravel-OCI8 Version 9.2.0

**Workaround**

As we spotted that this bug was introduced in the 9.0.4 release (https://github.com/yajra/laravel-oci8/pull/735/files#diff-7f7dccef7d6c61cad0d731ccd68ba192f1709deb333679cf51931b0f0d661e75R79), we forced composer to install a 9.0.3 version.

