### PR TITLE
feat: change limit character for 12c02 #762

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ class Config {
 
 Then run your laravel installation...
 
+## Oracle Max Name Length
+
+By default, DB object name are limited to 30 characters. To increase the limit, you can set the `ORA_MAX_NAME_LEN=128` in your `.env` file.
+
+Note: this config requires **Oracle 12c02 or higher**.
+
 ## [Laravel 5.2++] Oracle User Provider
 
 When using oracle, we may encounter a problem on authentication because oracle queries are case sensitive by default.

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -353,6 +353,7 @@ class Oci8Connection extends Connection
     public function withSchemaPrefix(Grammar $grammar)
     {
         $grammar->setSchemaPrefix($this->getConfigSchemaPrefix());
+        $grammar->setMaxLength($this->getConfigMaxLength());
 
         return $grammar;
     }
@@ -365,6 +366,16 @@ class Oci8Connection extends Connection
     protected function getConfigSchemaPrefix()
     {
         return isset($this->config['prefix_schema']) ? $this->config['prefix_schema'] : '';
+    }
+
+    /**
+     * Get config max length.
+     *
+     * @return string
+     */
+    protected function getConfigMaxLength()
+    {
+        return isset($this->config['max_name_len']) ? $this->config['max_name_len'] : 30;
     }
 
     /**

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -25,6 +25,11 @@ class OracleGrammar extends Grammar
     protected $schema_prefix = '';
 
     /**
+     * @var int
+     */
+    protected $max_length;
+
+    /**
      * Compile a delete statement with joins into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -262,6 +267,16 @@ class OracleGrammar extends Grammar
     }
 
     /**
+     * Get max length.
+     *
+     * @return int
+     */
+    public function getMaxLength()
+    {
+        return ! empty($this->max_length) ? $this->max_length : 30;
+    }
+
+    /**
      * Set the schema prefix.
      *
      * @param  string  $prefix
@@ -269,6 +284,16 @@ class OracleGrammar extends Grammar
     public function setSchemaPrefix($prefix)
     {
         $this->schema_prefix = $prefix;
+    }
+
+    /**
+     * Set max length.
+     *
+     * @param  int  $length
+     */
+    public function setMaxLength($length)
+    {
+        $this->max_length = $length;
     }
 
     /**

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -27,7 +27,7 @@ class OracleGrammar extends Grammar
     /**
      * @var int
      */
-    protected $max_length;
+    protected $maxLength;
 
     /**
      * Compile a delete statement with joins into SQL.
@@ -273,7 +273,7 @@ class OracleGrammar extends Grammar
      */
     public function getMaxLength()
     {
-        return ! empty($this->max_length) ? $this->max_length : 30;
+        return ! empty($this->maxLength) ? $this->maxLength : 30;
     }
 
     /**
@@ -293,7 +293,7 @@ class OracleGrammar extends Grammar
      */
     public function setMaxLength($length)
     {
-        $this->max_length = $length;
+        $this->maxLength = $length;
     }
 
     /**

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -22,7 +22,7 @@ class OracleGrammar extends Grammar
     /**
      * @var string
      */
-    protected $schema_prefix = '';
+    protected $schemaPrefix = '';
 
     /**
      * @var int
@@ -263,7 +263,7 @@ class OracleGrammar extends Grammar
      */
     public function getSchemaPrefix()
     {
-        return ! empty($this->schema_prefix) ? $this->wrapValue($this->schema_prefix).'.' : '';
+        return ! empty($this->schemaPrefix) ? $this->wrapValue($this->schemaPrefix).'.' : '';
     }
 
     /**
@@ -283,7 +283,7 @@ class OracleGrammar extends Grammar
      */
     public function setSchemaPrefix($prefix)
     {
-        $this->schema_prefix = $prefix;
+        $this->schemaPrefix = $prefix;
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -42,7 +42,7 @@ class OracleGrammar extends Grammar
     /**
      * @var int
      */
-    protected $max_length = 30;
+    protected $maxLength = 30;
 
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
@@ -107,7 +107,7 @@ class OracleGrammar extends Grammar
      */
     public function getMaxLength()
     {
-        return ! empty($this->max_length) ? $this->max_length : 30;
+        return ! empty($this->maxLength) ? $this->maxLength : 30;
     }
 
     /**
@@ -127,7 +127,7 @@ class OracleGrammar extends Grammar
      */
     public function setMaxLength($length)
     {
-        $this->max_length = $length;
+        $this->maxLength = $length;
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -37,7 +37,7 @@ class OracleGrammar extends Grammar
     /**
      * @var string
      */
-    protected $schema_prefix = '';
+    protected $schemaPrefix = '';
 
     /**
      * @var int
@@ -97,7 +97,7 @@ class OracleGrammar extends Grammar
      */
     public function getSchemaPrefix()
     {
-        return ! empty($this->schema_prefix) ? $this->schema_prefix.'.' : '';
+        return ! empty($this->schemaPrefix) ? $this->schemaPrefix.'.' : '';
     }
 
     /**
@@ -117,7 +117,7 @@ class OracleGrammar extends Grammar
      */
     public function setSchemaPrefix($prefix)
     {
-        $this->schema_prefix = $prefix;
+        $this->schemaPrefix = $prefix;
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -40,6 +40,11 @@ class OracleGrammar extends Grammar
     protected $schema_prefix = '';
 
     /**
+     * @var int
+     */
+    protected $max_length = 30;
+
+    /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *
      * @var bool
@@ -96,6 +101,16 @@ class OracleGrammar extends Grammar
     }
 
     /**
+     * Get max length.
+     *
+     * @return int
+     */
+    public function getMaxLength()
+    {
+        return ! empty($this->max_length) ? $this->max_length : 30;
+    }
+
+    /**
      * Set the schema prefix.
      *
      * @param  string  $prefix
@@ -103,6 +118,16 @@ class OracleGrammar extends Grammar
     public function setSchemaPrefix($prefix)
     {
         $this->schema_prefix = $prefix;
+    }
+
+    /**
+     * Set max length.
+     *
+     * @param  int  $length
+     */
+    public function setMaxLength($length)
+    {
+        $this->max_length = $length;
     }
 
     /**
@@ -369,7 +394,8 @@ class OracleGrammar extends Grammar
     private function dropConstraint(Blueprint $blueprint, Fluent $command, $type)
     {
         $table = $this->wrapTable($blueprint);
-        $index = substr($command->index, 0, 30);
+
+        $index = substr($command->index, 0, $this->getMaxLength());
 
         if ($type === 'index') {
             return "drop index {$index}";

--- a/src/Oci8/Schema/OracleAutoIncrementHelper.php
+++ b/src/Oci8/Schema/OracleAutoIncrementHelper.php
@@ -93,10 +93,9 @@ class OracleAutoIncrementHelper
      */
     private function createObjectName($prefix, $table, $col, $type)
     {
-        // max object name length is 30 chars
-        $max_length = $this->connection->getSchemaGrammar()->getMaxLength();
+        $maxLength = $this->connection->getSchemaGrammar()->getMaxLength();
 
-        return substr($prefix.$table.'_'.$col.'_'.$type, 0, $max_length);
+        return substr($prefix.$table.'_'.$col.'_'.$type, 0, $maxLength);
     }
 
     /**

--- a/src/Oci8/Schema/OracleAutoIncrementHelper.php
+++ b/src/Oci8/Schema/OracleAutoIncrementHelper.php
@@ -83,7 +83,7 @@ class OracleAutoIncrementHelper
     }
 
     /**
-     * Create an object name that limits to 30 or 126 chars depending on the server version.
+     * Create an object name that limits to 30 or 128 chars depending on the server version.
      *
      * @param  string  $prefix
      * @param  string  $table
@@ -93,14 +93,10 @@ class OracleAutoIncrementHelper
      */
     private function createObjectName($prefix, $table, $col, $type)
     {
-        $version = (int) filter_var($this->connection->getConfig('server_version'), FILTER_SANITIZE_NUMBER_INT);
+        // max object name length is 30 chars
+        $max_length = $this->connection->getSchemaGrammar()->getMaxLength();
 
-        $maxLength = 30;
-        if ($version >= 12) {
-            $maxLength = 126;
-        }
-
-        return substr($prefix.$table.'_'.$col.'_'.$type, 0, $maxLength);
+        return substr($prefix.$table.'_'.$col.'_'.$type, 0, $max_length);
     }
 
     /**

--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -28,11 +28,11 @@ class OracleBlueprint extends Blueprint
     protected $prefix;
 
     /**
-     * Database table max_length variable.
+     * Database table max length variable.
      *
      * @var int
      */
-    protected $max_length = 30;
+    protected $maxLength = 30;
 
     /**
      * Set table prefix settings.
@@ -51,7 +51,7 @@ class OracleBlueprint extends Blueprint
      */
     public function setMaxLength($maxLength = 30)
     {
-        $this->max_length = $maxLength;
+        $this->maxLength = $maxLength;
     }
 
     /**
@@ -75,9 +75,9 @@ class OracleBlueprint extends Blueprint
 
             $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
-            $index = str_replace(['-', '.'], '_', $index);
-            while (strlen($index) > $this->max_length) {
-                $parts = explode('_', $index);
+        $index = str_replace(['-', '.'], '_', $index);
+        while (strlen($index) > $this->maxLength) {
+            $parts = explode('_', $index);
 
                 for ($i = 0; $i < count($parts); $i++) {
                     // if any part is longer than 2 chars, take one off

--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -28,6 +28,13 @@ class OracleBlueprint extends Blueprint
     protected $prefix;
 
     /**
+     * Database table max_length variable.
+     *
+     * @var int
+     */
+    protected $max_length = 30;
+
+    /**
      * Set table prefix settings.
      *
      * @param  string  $prefix
@@ -35,6 +42,16 @@ class OracleBlueprint extends Blueprint
     public function setTablePrefix($prefix = '')
     {
         $this->prefix = $prefix;
+    }
+
+    /**
+     * Set index/table max length name settings.
+     *
+     * @param  int  $maxLength
+     */
+    public function setMaxLength($maxLength = 30)
+    {
+        $this->max_length = $maxLength;
     }
 
     /**
@@ -58,11 +75,9 @@ class OracleBlueprint extends Blueprint
 
             $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
-            $index = str_replace(['-', '.'], '_', $index);
-
-            // shorten the name if it is longer than 30 chars
-            while (strlen($index) > 30) {
-                $parts = explode('_', $index);
+        $index = str_replace(['-', '.'], '_', $index);
+        while (strlen($index) > $this->max_length) {
+            $parts = explode('_', $index);
 
                 for ($i = 0; $i < count($parts); $i++) {
                     // if any part is longer than 2 chars, take one off

--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -28,7 +28,7 @@ class OracleBlueprint extends Blueprint
     protected $prefix;
 
     /**
-     * Database table max length variable.
+     * Database object max length variable.
      *
      * @var int
      */
@@ -45,7 +45,7 @@ class OracleBlueprint extends Blueprint
     }
 
     /**
-     * Set index/table max length name settings.
+     * Set database object max length name settings.
      *
      * @param  int  $maxLength
      */

--- a/src/Oci8/Schema/OracleBuilder.php
+++ b/src/Oci8/Schema/OracleBuilder.php
@@ -61,6 +61,7 @@ class OracleBuilder extends Builder
     {
         $blueprint = new OracleBlueprint($table, $callback);
         $blueprint->setTablePrefix($this->connection->getTablePrefix());
+        $blueprint->setMaxLength($this->grammar->getMaxLength());
 
         return $blueprint;
     }

--- a/src/config/oracle.php
+++ b/src/config/oracle.php
@@ -16,6 +16,7 @@ return [
         'edition'        => env('DB_EDITION', 'ora$base'),
         'server_version' => env('DB_SERVER_VERSION', '11g'),
         'load_balance'   => env('DB_LOAD_BALANCE', 'yes'),
+        'max_name_len'   => env('ORA_MAX_NAME_LEN', 30),
         'dynamic'        => [],
     ],
     'sessionVars' => [


### PR DESCRIPTION
Cherry-picked from https://github.com/yajra/laravel-oci8/pull/762.

## Usage

Set `ORA_MAX_NAME_LEN=128` on your `.env` file to the new DB object max length.