### PR TITLE
fix to sqlRawSql

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -329,7 +329,9 @@ class Oci8Connection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar());
+        ($grammar = new QueryGrammar)->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -384,7 +386,9 @@ class Oci8Connection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar());
+        ($grammar = new SchemaGrammar)->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**


### PR DESCRIPTION
Laravel was updated to allow new functions like `toRawSql()`, but, for this, the reference for the connection should be set in grammars. This update does this, based on MySQL and other standard drivers.

Reference's Link: 
https://github.com/laravel/framework/blob/3cd9bcb25dbfb4e70c9b96dd5b9c2ce109583217/src/Illuminate/Database/MySqlConnection.php#L46

https://github.com/laravel/framework/blob/3cd9bcb25dbfb4e70c9b96dd5b9c2ce109583217/src/Illuminate/Database/MySqlConnection.php#L72