### PR TITLE
fix: read sessionVars config read from current database connection

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -58,14 +58,15 @@ class Oci8ServiceProvider extends ServiceProvider
             }
 
             // set oracle session variables
-            $defaultSessionVars = [
+            $defaultConnection = config('database.default');
+            $sessionVars = [
                 'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
                 'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',
                 'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
                 'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
                 'NLS_NUMERIC_CHARACTERS'  => '.,',
+                ...config("database.connections.$defaultConnection.sessionVars", []),
             ];
-            $sessionVars = config('database.connections.sessionVars', $defaultSessionVars);
 
             // Like Postgres, Oracle allows the concept of "schema"
             if (isset($config['schema'])) {

--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -58,14 +58,13 @@ class Oci8ServiceProvider extends ServiceProvider
             }
 
             // set oracle session variables
-            $defaultConnection = config('database.default');
             $sessionVars = [
                 'NLS_TIME_FORMAT'         => 'HH24:MI:SS',
                 'NLS_DATE_FORMAT'         => 'YYYY-MM-DD HH24:MI:SS',
                 'NLS_TIMESTAMP_FORMAT'    => 'YYYY-MM-DD HH24:MI:SS',
                 'NLS_TIMESTAMP_TZ_FORMAT' => 'YYYY-MM-DD HH24:MI:SS TZH:TZM',
                 'NLS_NUMERIC_CHARACTERS'  => '.,',
-                ...config("database.connections.$defaultConnection.sessionVars", []),
+                ...($config['sessionVars'] ?? []),
             ];
 
             // Like Postgres, Oracle allows the concept of "schema"

--- a/tests/Functional/SessionVarsTest.php
+++ b/tests/Functional/SessionVarsTest.php
@@ -3,9 +3,6 @@
 namespace Yajra\Oci8\Tests\Functional;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Yajra\Oci8\Query\Grammars\OracleGrammar;
-use Yajra\Oci8\Query\OracleBuilder as Builder;
-use Yajra\Oci8\Query\Processors\OracleProcessor;
 use Yajra\Oci8\Tests\TestCase;
 
 class SessionVarsTest extends TestCase
@@ -13,7 +10,7 @@ class SessionVarsTest extends TestCase
     use DatabaseTransactions;
 
     /**
-     * Configure custom sessionVars
+     * Configure custom sessionVars.
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Functional/SessionVarsTest.php
+++ b/tests/Functional/SessionVarsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Yajra\Oci8\Query\Grammars\OracleGrammar;
+use Yajra\Oci8\Query\OracleBuilder as Builder;
+use Yajra\Oci8\Query\Processors\OracleProcessor;
+use Yajra\Oci8\Tests\TestCase;
+
+class SessionVarsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * Configure custom sessionVars
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('database.connections.oracle.sessionVars', [
+            // Adds microseconds
+            'NLS_TIMESTAMP_FORMAT' => 'YYYY-MM-DD HH24:MI:SS.FF6',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_redefine_timestamp_format()
+    {
+        $this->getConnection()->table('users')->truncate();
+        $data = ['id' => 2, 'name' => 'Foo', 'email' => 'foo@example.com', 'created_at' => '2023-11-28 13:14:15.123456'];
+
+        $this->getConnection()->table('users')->insert($data);
+
+        $this->assertDatabaseCount('users', 1);
+        $user = $this->getConnection()->table('users')->first();
+        $this->assertSame('2023-11-28 13:14:15.123456', $user->created_at);
+    }
+}


### PR DESCRIPTION

Fixes https://github.com/yajra/laravel-oci8/issues/811 and improves handle of default values.