### PR TITLE
fix: ORA-38104: Columns referenced in the ON Clause cannot be updated

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -675,11 +675,16 @@ class OracleGrammar extends Grammar
         $sql .= ' on ('.$on.') ';
 
         if ($update) {
-            $update = collect($update)->map(function ($value, $key) {
-                return is_numeric($key)
-                    ? $this->wrap($value).' = '.$this->wrap('laravel_source.'.$value)
-                    : $this->wrap($key).' = '.$this->parameter($value);
-            })->implode(', ');
+            $update = collect($update)
+                ->reject(function ($value, $key) use ($uniqueBy) {
+                    return in_array($value, $uniqueBy);
+                })
+                ->map(function ($value, $key) {
+                    return is_numeric($key)
+                        ? $this->wrap($value).' = '.$this->wrap('laravel_source.'.$value)
+                        : $this->wrap($key).' = '.$this->parameter($value);
+                })
+                ->implode(', ');
 
             $sql .= 'when matched then update set '.$update.' ';
         }

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -2232,7 +2232,7 @@ class Oci8QueryBuilderTest extends TestCase
         $builder->getConnection()
             ->shouldReceive('affectingStatement')
             ->once()
-            ->with('merge into "USERS" using (select ? as "EMAIL", ? as "NAME" from dual union all select ? as "EMAIL", ? as "NAME" from dual) "LARAVEL_SOURCE" on ("LARAVEL_SOURCE"."EMAIL" = "USERS"."EMAIL") when matched then update set "EMAIL" = "LARAVEL_SOURCE"."EMAIL", "NAME" = "LARAVEL_SOURCE"."NAME" when not matched then insert ("EMAIL", "NAME") values ("LARAVEL_SOURCE"."EMAIL", "LARAVEL_SOURCE"."NAME")', ['foo', 'bar', 'foo2', 'bar2'])
+            ->with('merge into "USERS" using (select ? as "EMAIL", ? as "NAME" from dual union all select ? as "EMAIL", ? as "NAME" from dual) "LARAVEL_SOURCE" on ("LARAVEL_SOURCE"."EMAIL" = "USERS"."EMAIL") when matched then update set "NAME" = "LARAVEL_SOURCE"."NAME" when not matched then insert ("EMAIL", "NAME") values ("LARAVEL_SOURCE"."EMAIL", "LARAVEL_SOURCE"."NAME")', ['foo', 'bar', 'foo2', 'bar2'])
             ->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);


### PR DESCRIPTION
Fix scenario where empty update fields were provided thus all provided column will be included in the update. Fields used on uniqueBy must be removed from update list.

```php
Policy::upsert($values, $uniqueBy);
```
