### PR TITLE
fix: missing auto_increment key

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -218,6 +218,7 @@ class OracleGrammar extends Grammar
     {
         return "select column_name as name,
                 nvl(data_type_mod, data_type) as type_name,
+                null as auto_increment,
                 data_type as type,
                 data_length as length,
                 nullable,

--- a/tests/Functional/SchemaTest.php
+++ b/tests/Functional/SchemaTest.php
@@ -64,7 +64,6 @@ class SchemaTest extends TestCase
 
     public function testGetColumns()
     {
-        Schema::drop('foo');
         Schema::create('foo', function (Blueprint $table) {
             $table->id();
             $table->string('bar')->nullable();

--- a/tests/Functional/SchemaTest.php
+++ b/tests/Functional/SchemaTest.php
@@ -64,6 +64,7 @@ class SchemaTest extends TestCase
 
     public function testGetColumns()
     {
+        Schema::drop('foo');
         Schema::create('foo', function (Blueprint $table) {
             $table->id();
             $table->string('bar')->nullable();
@@ -72,6 +73,7 @@ class SchemaTest extends TestCase
 
         $columns = Schema::getColumns('foo');
 
+        $this->assertArrayHasKey('auto_increment', $columns[0]);
         $this->assertCount(3, $columns);
         $this->assertTrue(collect($columns)->contains(
             fn ($column) => $column['name'] === 'ID' && $column['type'] === 'NUMBER' && $column['nullable'] === 'N'


### PR DESCRIPTION
fix: #837

Note: The `auto_increment` flag is not available on the Oracle definition for the version I am using afaik. A null placeholder is added for auto_increment to fix the missing key error. Use with caution until a better solution is found.