### PR TITLE
feat: Improve schema grammar

### DIFF
--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -198,7 +198,74 @@ class OracleProcessor extends Processor
     public function processColumns($results)
     {
         return array_map(function ($result) {
-            return (array) $result;
+            $result = (object) $result;
+
+            $type = strtolower($result->type);
+            $precision = (int) $result->precision;
+            $places = (int) $result->places;
+            $length = (int) $result->data_length;
+
+            switch ($typeName = strtolower($result->type_name)) {
+                case 'number':
+                    if ($precision === 19 && $places === 0) {
+                        $type = 'bigint';
+                    } elseif ($precision === 10 && $places === 0) {
+                        $type = 'int';
+                    } elseif ($precision === 5 && $places === 0) {
+                        $type = 'smallint';
+                    } elseif ($precision === 1 && $places === 0) {
+                        $type = 'boolean';
+                    } elseif ($places > 0) {
+                        $type = 'decimal';
+                    }
+
+                    break;
+
+                case 'varchar':
+                case 'varchar2':
+                case 'nvarchar2':
+                case 'char':
+                case 'nchar':
+                    $length = (int) $result->char_length;
+                    break;
+                default:
+                    $type = $typeName;
+            }
+
+            return [
+                'name' => strtolower($result->name),
+                'type_name' => strtolower($result->type_name),
+                'type' => $type,
+                'nullable' => (bool) $result->nullable,
+                'default' => $result->default,
+                'auto_increment' => (bool) $result->auto_increment,
+                'comment' => $result->comment != '' ? $result->comment : null,
+                'length' => $length,
+                'precision' => $precision,
+            ];
+        }, $results);
+    }
+
+    /**
+     * Process the results of a columns query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processForeignKeys($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => strtolower($result->name),
+                'columns' => explode(',', strtolower($result->columns)),
+                'foreign_schema' => strtolower($result->foreign_schema),
+                'foreign_table' => strtolower($result->foreign_table),
+                'foreign_columns' => explode(',', strtolower($result->foreign_columns)),
+                'on_update' => strtolower($result->on_update),
+                'on_delete' => $result->on_delete,
+            ];
         }, $results);
     }
 }

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -299,6 +299,60 @@ class Oci8SchemaGrammarTest extends TestCase
         $this->assertEquals($expected, $sql);
     }
 
+    public function testCompileColumnsMethod()
+    {
+        $grammar = $this->getGrammar();
+        $expected = '
+            select 
+                t.column_name as name,
+                nvl(t.data_type_mod, data_type) as type_name,
+                null as auto_increment,
+                t.data_type as type,
+                t.data_length,
+                t.char_length,
+                t.data_precision as precision,
+                t.data_scale as places,
+                decode(t.nullable, \'Y\', 1, 0) as nullable,
+                t.data_default as "default",
+                c.comments as "comment"
+            from all_tab_cols t
+            left join all_col_comments c on t.owner = c.owner and t.table_name = c.table_name AND t.column_name = c.column_name
+            where upper(t.table_name) = upper(\'test_table\')
+                and upper(t.owner) = upper(\'schema\')
+            order by
+                t.column_id
+        ';
+
+        $sql = $grammar->compileColumns('schema', 'test_table');
+        $this->assertEquals($expected, $sql);
+    }
+
+    public function testCompileForeignKeysMethod()
+    {
+        $grammar = $this->getGrammar();
+        $expected = '
+            select
+                kc.constraint_name as name,
+                LISTAGG(kc.column_name, \',\') WITHIN GROUP (ORDER BY kc.position) as columns,
+                rc.r_owner as foreign_schema,
+                kcr.table_name as foreign_table,
+                LISTAGG(kcr.column_name, \',\') WITHIN GROUP (ORDER BY kcr.position) as foreign_columns,
+                rc.delete_rule AS "on_delete",
+                null AS "on_update"
+            from all_cons_columns kc 
+            inner join all_constraints rc ON kc.constraint_name = rc.constraint_name 
+            inner join all_cons_columns kcr ON kcr.constraint_name = rc.r_constraint_name 
+            where kc.table_name = upper(\'test_table\') 
+                and kc.owner = upper(\'schema\') 
+                and rc.constraint_type = \'R\'
+            group by 
+                kc.constraint_name, rc.r_owner, kcr.table_name, kc.constraint_name, rc.delete_rule
+        ';
+
+        $sql = $grammar->compileForeignKeys('schema', 'test_table');
+        $this->assertEquals($expected, $sql);
+    }
+
     public function testDropTableWithPrefix()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Goal:
- Be able to use correctly project `barryvdh/laravel-ide-helper`,  especially command  `php artisan ide-helper:models` with oracle

Improves:
- change compileColumns
- add compileForeignKeys
- add and change tests
- improve getColumns / compileColumns, before it was possible getColumns only on user schema, now it possible retrieve columns from others schemas

Possible break change:
- change compileColumns fields:
   - string fields (like column name, column type) to lower case;
   - nullable to boolean;
   - numeric fields (like length) to int;
   - change type value based on precision and scale;
   - change length value based on type; 