### PR TITLE
fix: migration when column name has space

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -900,10 +900,8 @@ class OracleGrammar extends Grammar
      */
     protected function wrapValue($value)
     {
-        if ($this->isReserved($value)) {
-            return Str::upper(parent::wrapValue($value));
-        }
+        $value = Str::upper($value);
 
-        return $value !== '*' ? sprintf($this->wrapper, $value) : $value;
+        return parent::wrapValue($value);
     }
 }

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -217,7 +217,7 @@ class OracleGrammar extends Grammar
     public function compileColumns($schema, $table)
     {
         return "
-            select 
+            select
                 t.column_name as name,
                 nvl(t.data_type_mod, data_type) as type_name,
                 null as auto_increment,
@@ -249,13 +249,13 @@ class OracleGrammar extends Grammar
                 LISTAGG(kcr.column_name, ',') WITHIN GROUP (ORDER BY kcr.position) as foreign_columns,
                 rc.delete_rule AS \"on_delete\",
                 null AS \"on_update\"
-            from all_cons_columns kc 
-            inner join all_constraints rc ON kc.constraint_name = rc.constraint_name 
-            inner join all_cons_columns kcr ON kcr.constraint_name = rc.r_constraint_name 
-            where kc.table_name = upper('{$table}') 
-                and kc.owner = upper('{$schema}') 
+            from all_cons_columns kc
+            inner join all_constraints rc ON kc.constraint_name = rc.constraint_name
+            inner join all_cons_columns kcr ON kcr.constraint_name = rc.r_constraint_name
+            where kc.table_name = upper('{$table}')
+                and kc.owner = upper('{$schema}')
                 and rc.constraint_type = 'R'
-            group by 
+            group by
                 kc.constraint_name, rc.r_owner, kcr.table_name, kc.constraint_name, rc.delete_rule
         ";
     }

--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -75,7 +75,7 @@ class OracleBlueprint extends Blueprint
 
             $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
-            $index = str_replace(['-', '.'], '_', $index);
+            $index = str_replace(['-', '.', ' '], '_', $index);
             while (strlen($index) > $this->maxLength) {
                 $parts = explode('_', $index);
 

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -27,7 +27,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table users ( id number(10,0) not null, email varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -53,7 +53,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table users ( id number(10,0) not null, "GROUP" varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "USERS" ( "ID" number(10,0) not null, "GROUP" varchar2(255) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -69,7 +69,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table users ( id number(10,0) not null, email varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -89,7 +89,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table prefix_users ( id number(10,0) not null, email varchar2(255) not null, foo_id number(10,0) not null, constraint users_foo_id_fk foreign key ( foo_id ) references prefix_orders ( id ), constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, "FOO_ID" number(10,0) not null, constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "PREFIX_ORDERS" ( "ID" ), constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -106,7 +106,7 @@ class Oci8SchemaGrammarTest extends TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals(
-            'create table users ( id number(10,0) not null, first_name nvarchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+            'create table "USERS" ( "ID" number(10,0) not null, "FIRST_NAME" nvarchar2(255) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]
         );
     }
@@ -123,7 +123,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table users ( id number(10,0) not null, email varchar2(255) default \'user@test.com\' not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) default \'user@test.com\' not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -141,7 +141,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table prefix_users ( id number(10,0) not null, email varchar2(255) not null, constraint prefix_users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint prefix_users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -160,7 +160,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table prefix_users ( id number(10,0) not null, email varchar2(255) not null, constraint prefix_users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint prefix_users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -181,7 +181,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table prefix_users ( id number(10,0) not null, email varchar2(255) not null, foo_id number(10,0) not null, constraint users_foo_id_fk foreign key ( foo_id ) references prefix_orders ( id ), constraint prefix_users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, "FOO_ID" number(10,0) not null, constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "PREFIX_ORDERS" ( "ID" ), constraint prefix_users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -201,7 +201,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table prefix_users ( id number(10,0) not null, email varchar2(255) not null, foo_id number(10,0) not null, constraint users_foo_id_fk foreign key ( foo_id ) references prefix_orders ( id ) on delete cascade, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, "FOO_ID" number(10,0) not null, constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "PREFIX_ORDERS" ( "ID" ) on delete cascade, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -216,7 +216,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( id number(10,0) not null, email varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('alter table "USERS" add ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -231,7 +231,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( id number(10,0) not null, email varchar2(255) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('alter table "USERS" add ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -250,7 +250,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users add ( id number(10,0) not null, email varchar2(255) not null, constraint prefix_users_id_pk primary key ( id ) )',
+        $this->assertEquals('alter table "PREFIX_USERS" add ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint prefix_users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -269,7 +269,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users add ( id number(10,0) not null, email varchar2(255) not null, constraint prefix_users_id_pk primary key ( id ) )',
+        $this->assertEquals('alter table "PREFIX_USERS" add ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint prefix_users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -280,7 +280,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop table users', $statements[0]);
+        $this->assertEquals('drop table "USERS"', $statements[0]);
     }
 
     public function testCompileTableExistsMethod()
@@ -303,7 +303,7 @@ class Oci8SchemaGrammarTest extends TestCase
     {
         $grammar = $this->getGrammar();
         $expected = '
-            select 
+            select
                 t.column_name as name,
                 nvl(t.data_type_mod, data_type) as type_name,
                 null as auto_increment,
@@ -339,13 +339,13 @@ class Oci8SchemaGrammarTest extends TestCase
                 LISTAGG(kcr.column_name, \',\') WITHIN GROUP (ORDER BY kcr.position) as foreign_columns,
                 rc.delete_rule AS "on_delete",
                 null AS "on_update"
-            from all_cons_columns kc 
-            inner join all_constraints rc ON kc.constraint_name = rc.constraint_name 
-            inner join all_cons_columns kcr ON kcr.constraint_name = rc.r_constraint_name 
-            where kc.table_name = upper(\'test_table\') 
-                and kc.owner = upper(\'schema\') 
+            from all_cons_columns kc
+            inner join all_constraints rc ON kc.constraint_name = rc.constraint_name
+            inner join all_cons_columns kcr ON kcr.constraint_name = rc.r_constraint_name
+            where kc.table_name = upper(\'test_table\')
+                and kc.owner = upper(\'schema\')
                 and rc.constraint_type = \'R\'
-            group by 
+            group by
                 kc.constraint_name, rc.r_owner, kcr.table_name, kc.constraint_name, rc.delete_rule
         ';
 
@@ -365,7 +365,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop table prefix_users', $statements[0]);
+        $this->assertEquals('drop table "PREFIX_USERS"', $statements[0]);
     }
 
     public function testDropColumn()
@@ -375,14 +375,14 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users drop ( foo )', $statements[0]);
+        $this->assertEquals('alter table "USERS" drop ( "FOO" )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn(['foo', 'bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users drop ( foo, bar )', $statements[0]);
+        $this->assertEquals('alter table "USERS" drop ( "FOO", "BAR" )', $statements[0]);
     }
 
     public function testDropPrimary()
@@ -392,7 +392,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "USERS" drop constraint foo', $statements[0]);
     }
 
     public function testDropUnique()
@@ -402,7 +402,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "USERS" drop constraint foo', $statements[0]);
     }
 
     public function testDropIndex()
@@ -422,7 +422,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "USERS" drop constraint foo', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -432,7 +432,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users drop ( created_at, updated_at )', $statements[0]);
+        $this->assertEquals('alter table "USERS" drop ( "CREATED_AT", "UPDATED_AT" )', $statements[0]);
     }
 
     public function testRenameTable()
@@ -442,7 +442,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users rename to foo', $statements[0]);
+        $this->assertEquals('alter table "USERS" rename to "FOO"', $statements[0]);
     }
 
     public function testRenameTableWithPrefix()
@@ -454,7 +454,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users rename to prefix_foo', $statements[0]);
+        $this->assertEquals('alter table "PREFIX_USERS" rename to "PREFIX_FOO"', $statements[0]);
     }
 
     public function testAddingPrimaryKey()
@@ -464,7 +464,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add constraint bar primary key (foo)', $statements[0]);
+        $this->assertEquals('alter table "USERS" add constraint bar primary key ("FOO")', $statements[0]);
     }
 
     public function testAddingPrimaryKeyWithConstraintAutomaticName()
@@ -474,7 +474,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add constraint users_foo_pk primary key (foo)', $statements[0]);
+        $this->assertEquals('alter table "USERS" add constraint users_foo_pk primary key ("FOO")', $statements[0]);
     }
 
     public function testAddingPrimaryKeyWithConstraintAutomaticNameGreaterThanThirtyCharacters()
@@ -485,7 +485,7 @@ class Oci8SchemaGrammarTest extends TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals(
-            'alter table users add constraint user_rese_passwor_secre_cod_pk primary key (reset_password_secret_code)',
+            'alter table "USERS" add constraint user_rese_passwor_secre_cod_pk primary key ("RESET_PASSWORD_SECRET_CODE")',
             $statements[0]);
     }
 
@@ -496,7 +496,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add constraint bar unique ( foo )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add constraint bar unique ( "FOO" )', $statements[0]);
     }
 
     public function testAddingDefinedUniqueKeyWithPrefix()
@@ -511,7 +511,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users add constraint bar unique ( foo )', $statements[0]);
+        $this->assertEquals('alter table "PREFIX_USERS" add constraint bar unique ( "FOO" )', $statements[0]);
     }
 
     public function testAddingGeneratedUniqueKeyWithPrefix()
@@ -526,7 +526,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table prefix_users add constraint prefix_users_foo_uk unique ( foo )',
+        $this->assertEquals('alter table "PREFIX_USERS" add constraint prefix_users_foo_uk unique ( "FOO" )',
             $statements[0]);
     }
 
@@ -538,7 +538,7 @@ class Oci8SchemaGrammarTest extends TestCase
 
         $this->assertEquals(1, count($statements));
 
-        $this->assertEquals('create index baz on users ( foo, bar )', $statements[0]);
+        $this->assertEquals('create index baz on "USERS" ( "FOO", "BAR" )', $statements[0]);
     }
 
     public function testAddingForeignKey()
@@ -548,7 +548,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add constraint users_foo_id_fk foreign key ( foo_id ) references orders ( id )',
+        $this->assertEquals('alter table "USERS" add constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "ORDERS" ( "ID" )',
             $statements[0]);
     }
 
@@ -559,7 +559,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add constraint users_foo_id_fk foreign key ( foo_id ) references orders ( id ) on delete cascade',
+        $this->assertEquals('alter table "USERS" add constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "ORDERS" ( "ID" ) on delete cascade',
             $statements[0]);
     }
 
@@ -570,7 +570,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( id number(10,0) not null, constraint users_id_pk primary key ( id ) )',
+        $this->assertEquals('alter table "USERS" add ( "ID" number(10,0) not null, constraint users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 
@@ -581,21 +581,21 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo varchar2(255) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" varchar2(255) not null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo varchar2(100) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" varchar2(100) not null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo varchar2(100) default \'bar\' null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" varchar2(100) default \'bar\' null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)
@@ -604,7 +604,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo varchar2(100) default CURRENT TIMESTAMP null )',
+        $this->assertEquals('alter table "USERS" add ( "FOO" varchar2(100) default CURRENT TIMESTAMP null )',
             $statements[0]);
     }
 
@@ -615,7 +615,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo clob not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" clob not null )', $statements[0]);
     }
 
     public function testAddingMediumText()
@@ -625,7 +625,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo clob not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" clob not null )', $statements[0]);
     }
 
     public function testAddingText()
@@ -635,7 +635,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo clob not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" clob not null )', $statements[0]);
     }
 
     public function testAddingChar()
@@ -645,14 +645,14 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo char(255) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" char(255) not null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->char('foo', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo char(1) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" char(1) not null )', $statements[0]);
     }
 
     public function testAddingBigInteger()
@@ -662,14 +662,14 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(19,0) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(19,0) not null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(19,0) not null, constraint users_foo_pk primary key ( foo ) )',
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(19,0) not null, constraint users_foo_pk primary key ( "FOO" ) )',
             $statements[0]);
     }
 
@@ -680,14 +680,14 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(10,0) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(10,0) not null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(10,0) not null, constraint users_foo_pk primary key ( foo ) )',
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(10,0) not null, constraint users_foo_pk primary key ( "FOO" ) )',
             $statements[0]);
     }
 
@@ -698,7 +698,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(7,0) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(7,0) not null )', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -708,7 +708,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(5,0) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(5,0) not null )', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -718,7 +718,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(3,0) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(3,0) not null )', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -728,12 +728,12 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo float(5) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" float(5) not null )', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->float('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertEquals('alter table users add ( foo float(126) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" float(126) not null )', $statements[0]);
     }
 
     public function testAddingDouble()
@@ -743,7 +743,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo float(126) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" float(126) not null )', $statements[0]);
     }
 
     public function testAddingDecimal()
@@ -753,7 +753,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo number(5, 2) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" number(5, 2) not null )', $statements[0]);
     }
 
     public function testAddingBoolean()
@@ -763,7 +763,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo char(1) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" char(1) not null )', $statements[0]);
     }
 
     public function testAddingEnum()
@@ -773,7 +773,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo varchar2(255) not null check (foo in (\'bar\', \'baz\')) )',
+        $this->assertEquals('alter table "USERS" add ( "FOO" varchar2(255) not null check ("FOO" in (\'bar\', \'baz\')) )',
             $statements[0]);
     }
 
@@ -784,7 +784,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo varchar2(255) default \'bar\' not null check (foo in (\'bar\', \'baz\')) )',
+        $this->assertEquals('alter table "USERS" add ( "FOO" varchar2(255) default \'bar\' not null check ("FOO" in (\'bar\', \'baz\')) )',
             $statements[0]);
     }
 
@@ -794,7 +794,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $blueprint->json('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table users add ( foo clob not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" clob not null )', $statements[0]);
     }
 
     public function testAddingJsonb()
@@ -803,7 +803,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $blueprint->jsonb('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table users add ( foo clob not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" clob not null )', $statements[0]);
     }
 
     public function testAddingDate()
@@ -813,7 +813,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo date not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" date not null )', $statements[0]);
     }
 
     public function testAddingDateTime()
@@ -823,7 +823,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo date not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" date not null )', $statements[0]);
     }
 
     public function testAddingTime()
@@ -833,7 +833,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo date not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" date not null )', $statements[0]);
     }
 
     public function testAddingTimeStamp()
@@ -843,7 +843,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo timestamp not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" timestamp not null )', $statements[0]);
     }
 
     public function testAddingTimeStampTz()
@@ -853,7 +853,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo timestamp with time zone not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" timestamp with time zone not null )', $statements[0]);
     }
 
     public function testAddingNullableTimeStamps()
@@ -863,7 +863,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( created_at timestamp null, updated_at timestamp null )',
+        $this->assertEquals('alter table "USERS" add ( "CREATED_AT" timestamp null, "UPDATED_AT" timestamp null )',
             $statements[0]);
     }
 
@@ -874,7 +874,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( created_at timestamp null, updated_at timestamp null )',
+        $this->assertEquals('alter table "USERS" add ( "CREATED_AT" timestamp null, "UPDATED_AT" timestamp null )',
             $statements[0]);
     }
 
@@ -885,7 +885,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( created_at timestamp with time zone null, updated_at timestamp with time zone null )',
+        $this->assertEquals('alter table "USERS" add ( "CREATED_AT" timestamp with time zone null, "UPDATED_AT" timestamp with time zone null )',
             $statements[0]);
     }
 
@@ -895,7 +895,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $blueprint->uuid('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table users add ( foo char(36) not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" char(36) not null )', $statements[0]);
     }
 
     public function testAddingBinary()
@@ -905,7 +905,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table users add ( foo blob not null )', $statements[0]);
+        $this->assertEquals('alter table "USERS" add ( "FOO" blob not null )', $statements[0]);
     }
 
     public function testBasicCreateTableWithPrimaryAndLongForeignKeys()
@@ -927,7 +927,7 @@ class Oci8SchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create table prefix_users ( id number(10,0) not null, email varchar2(255) not null, very_long_foo_bar_id number(10,0) not null, constraint prefix_users_very_long_foo_bar_id_fk foreign key ( very_long_foo_bar_id ) references prefix_orders ( id ), constraint prefix_users_id_pk primary key ( id ) )',
+        $this->assertEquals('create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, "VERY_LONG_FOO_BAR_ID" number(10,0) not null, constraint prefix_users_very_long_foo_bar_id_fk foreign key ( "VERY_LONG_FOO_BAR_ID" ) references "PREFIX_ORDERS" ( "ID" ), constraint prefix_users_id_pk primary key ( "ID" ) )',
             $statements[0]);
     }
 

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -31,6 +31,36 @@ class Oci8SchemaGrammarTest extends TestCase
             $statements[0]);
     }
 
+    public function testAddColumnWithSpace(): void
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('first name');
+
+        $conn = $this->getConnection();
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create table "USERS" ( "FIRST NAME" varchar2(255) not null )', $statements[0]);
+    }
+
+    public function testCreateIndexNameUsingColumnWithSpace()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('first name');
+        $blueprint->index('first name');
+
+        $conn = $this->getConnection();
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertEquals(2, count($statements));
+        $this->assertEquals('create table "USERS" ( "FIRST NAME" varchar2(255) not null )', $statements[0]);
+        $this->assertEquals('create index users_first_name_index on "USERS" ( "FIRST NAME" )', $statements[1]);
+    }
+
     protected function getConnection()
     {
         return m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
fix: index name when column name has space