### PR TITLE
Disabling foreign key constraints

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -976,4 +976,44 @@ class OracleGrammar extends Grammar
             $this->quoteString($table)
         );
     }
+
+    /**
+     * Compile the command to enable foreign key constraints.
+     *
+     * @return string
+     */
+    public function compileEnableForeignKeyConstraints()
+    {
+        return 'BEGIN
+            FOR R IN
+                ( SELECT \'ALTER TABLE \'||TABLE_NAME||\' ENABLE CONSTRAINT \'||CONSTRAINT_NAME AS STATEMENT
+                  FROM USER_CONSTRAINTS
+                  WHERE STATUS = \'DISABLED\'
+                  ORDER BY CASE CONSTRAINT_TYPE WHEN \'R\' THEN 2 ELSE 1 END
+                )
+                LOOP
+                    EXECUTE IMMEDIATE R.STATEMENT;
+                END LOOP;
+        END;';
+    }
+
+    /**
+     * Compile the command to disable foreign key constraints.
+     *
+     * @return string
+     */
+    public function compileDisableForeignKeyConstraints()
+    {
+        return 'BEGIN
+            FOR R IN
+                ( SELECT \'ALTER TABLE \'||TABLE_NAME||\' DISABLE CONSTRAINT \'||CONSTRAINT_NAME AS STATEMENT
+                  FROM USER_CONSTRAINTS
+                  WHERE STATUS = \'ENABLED\'
+                  ORDER BY CASE CONSTRAINT_TYPE WHEN \'R\' THEN 1 ELSE 2 END
+                )
+                LOOP
+                    EXECUTE IMMEDIATE R.STATEMENT;
+                END LOOP;
+        END;';
+    }
 }

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -1065,4 +1065,42 @@ class Oci8SchemaGrammarTest extends TestCase
 
         $this->assertEquals($expected, $statement);
     }
+
+    public function testCompileEnableForeignKeyConstraints()
+    {
+        $statement = $this->getGrammar()->compileEnableForeignKeyConstraints();
+
+        $expected = 'BEGIN
+            FOR R IN
+                ( SELECT \'ALTER TABLE \'||TABLE_NAME||\' ENABLE CONSTRAINT \'||CONSTRAINT_NAME AS STATEMENT
+                  FROM USER_CONSTRAINTS
+                  WHERE STATUS = \'DISABLED\'
+                  ORDER BY CASE CONSTRAINT_TYPE WHEN \'R\' THEN 2 ELSE 1 END
+                )
+                LOOP
+                    EXECUTE IMMEDIATE R.STATEMENT;
+                END LOOP;
+        END;';
+
+        $this->assertEquals($expected, $statement);
+    }
+
+    public function testCompileDisableForeignKeyConstraints()
+    {
+        $statement = $this->getGrammar()->compileDisableForeignKeyConstraints();
+
+        $expected = 'BEGIN
+            FOR R IN
+                ( SELECT \'ALTER TABLE \'||TABLE_NAME||\' DISABLE CONSTRAINT \'||CONSTRAINT_NAME AS STATEMENT
+                  FROM USER_CONSTRAINTS
+                  WHERE STATUS = \'ENABLED\'
+                  ORDER BY CASE CONSTRAINT_TYPE WHEN \'R\' THEN 1 ELSE 2 END
+                )
+                LOOP
+                    EXECUTE IMMEDIATE R.STATEMENT;
+                END LOOP;
+        END;';
+
+        $this->assertEquals($expected, $statement);
+    }
 }


### PR DESCRIPTION
Hi it's me again

this pr is for adding the following missing method 

```
compileEnableForeignKeyConstraints
compileDisableForeignKeyConstraints
```

this pr close the following issue too https://github.com/yajra/laravel-oci8/issues/488