### PR TITLE
fix: compileAdd with getColumn (laravel_framework_11.15.0)

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -269,7 +269,11 @@ class OracleGrammar extends Grammar
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
     {
-        $columns = implode(', ', $this->getColumns($blueprint));
+        if (method_exists($this, 'getColumn')) {
+            $columns = $this->getColumn($blueprint, $command->column);
+        } else {
+            $columns = implode(', ', $this->getColumns($blueprint));
+        }
 
         $sql = 'alter table '.$this->wrapTable($blueprint)." add ( $columns";
 


### PR DESCRIPTION
`OracleGrammar@compileAdd` now consumes the 
`$this->getColumn($blueprint, $command->column)`
coming in 
laravel/framework 11.15.0 (laravel/framework#51373)
as @hafezdivandari mentioned in #864

(`compileChange` I believe also needs a future update to consume `$command->column`)