### PR TITLE
feat: disable/enable foreign keys

### DIFF
--- a/src/Oci8/Schema/OracleBuilder.php
+++ b/src/Oci8/Schema/OracleBuilder.php
@@ -235,4 +235,28 @@ class OracleBuilder extends Builder
             )
         );
     }
+
+    /**
+     * Disable foreign key constraints.
+     *
+     * @return bool
+     */
+    public function disableForeignKeyConstraints()
+    {
+        return $this->connection->statement(
+            $this->grammar->compileDisableForeignKeyConstraints($this->connection->getConfig('username'))
+        );
+    }
+
+    /**
+     * Enable foreign key constraints.
+     *
+     * @return bool
+     */
+    public function enableForeignKeyConstraints()
+    {
+        return $this->connection->statement(
+            $this->grammar->compileEnableForeignKeyConstraints($this->connection->getConfig('username'))
+        );
+    }
 }

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -1065,4 +1065,50 @@ class Oci8SchemaGrammarTest extends TestCase
 
         $this->assertEquals($expected, $statement);
     }
+
+    public function testCompileEnableForeignKeyConstraints()
+    {
+        $statement = $this->getGrammar()->compileEnableForeignKeyConstraints('username');
+
+        $expected = 'begin
+            for s in (
+                SELECT \'alter table \' || c2.table_name || \' enable constraint \' || c2.constraint_name as statement
+                FROM all_constraints c
+                         INNER JOIN all_constraints c2
+                                    ON (c.constraint_name = c2.r_constraint_name AND c.owner = c2.owner)
+                         INNER JOIN all_cons_columns col
+                                    ON (c.constraint_name = col.constraint_name AND c.owner = col.owner)
+                WHERE c2.constraint_type = \'R\'
+                  AND c.owner = \'USERNAME\'
+                )
+                loop
+                    execute immediate s.statement;
+                end loop;
+        end;';
+
+        $this->assertEquals($expected, $statement);
+    }
+
+    public function testCompileDisableForeignKeyConstraints()
+    {
+        $statement = $this->getGrammar()->compileDisableForeignKeyConstraints('username');
+
+        $expected = 'begin
+            for s in (
+                SELECT \'alter table \' || c2.table_name || \' disable constraint \' || c2.constraint_name as statement
+                FROM all_constraints c
+                         INNER JOIN all_constraints c2
+                                    ON (c.constraint_name = c2.r_constraint_name AND c.owner = c2.owner)
+                         INNER JOIN all_cons_columns col
+                                    ON (c.constraint_name = col.constraint_name AND c.owner = col.owner)
+                WHERE c2.constraint_type = \'R\'
+                  AND c.owner = \'USERNAME\'
+                )
+                loop
+                    execute immediate s.statement;
+                end loop;
+        end;';
+
+        $this->assertEquals($expected, $statement);
+    }
 }


### PR DESCRIPTION
fix: #863
fix: #488

### Test Script

```php
class UsersSeeder extends Seeder
{
    /**
     * Run the database seeds.
     */
    public function run(): void
    {
        Schema::disableForeignKeyConstraints();
        // truncate all tables
        Permission::truncate();
        Role::truncate();
        User::truncate();

        // truncate pivot tables
        DB::table('role_user')->truncate();
        DB::table('permission_role')->truncate();
        DB::table('permission_user')->truncate();
        Schema::enableForeignKeyConstraints();
    }
}
```

### Command

```bash
php artisan db:seed UsersSeeder
```   