### PR TITLE
feat: Implement compileTables missing method

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -1045,20 +1045,4 @@ class OracleGrammar extends Grammar
                 all_tables.avg_row_len, all_tables.blocks, all_tab_comments.comments
             order by all_tab_comments.table_name';
     }
-    {
-        return 'select all_tab_comments.table_name  as "name",
-                all_tables.owner as "schema",
-                coalesce(round(sum(user_segments.bytes) / 1024 / 1024, 2), 0) as "size",
-                all_tab_comments.comments as "comments",
-                (select value from nls_database_parameters where parameter = \'nls_sort\') as "collation"
-            from all_tables
-                join all_tab_comments on all_tab_comments.table_name = all_tables.table_name
-                left join user_segments on user_segments.segment_name = all_tables.table_name
-            where all_tables.owner = \''.strtoupper($owner).'\'
-                and all_tab_comments.owner = \''.strtoupper($owner).'\'
-                and all_tab_comments.table_type in (\'TABLE\')
-            group by all_tab_comments.table_name, all_tables.owner, all_tables.num_rows,
-                all_tables.avg_row_len, all_tables.blocks, all_tab_comments.comments
-            order by all_tab_comments.table_name';
-    }
 }

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -1025,7 +1025,7 @@ class OracleGrammar extends Grammar
     /**
      * Compile the query to determine the tables.
      *
-     * @param  string $owner
+     * @param  string  $owner
      * @return string
      */
     public function compileTables(string $owner): string

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -1021,4 +1021,20 @@ class OracleGrammar extends Grammar
                 end loop;
         end;';
     }
+
+    /**
+     * Compile the query to determine the tables.
+     *
+     * @param string $owner
+     * @return string
+     */
+    public function compileTables(string $owner): string
+    {
+        return 'select all_tab_comments.table_name  as "name"
+            from all_tab_comments
+                join all_tables on all_tab_comments.table_name = all_tables.table_name
+            where all_tab_comments.owner = \''.strtoupper($owner).'\'
+                and all_tab_comments.table_type in (\'TABLE\')
+            order by all_tab_comments.table_name';
+    }
 }

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -1025,7 +1025,7 @@ class OracleGrammar extends Grammar
     /**
      * Compile the query to determine the tables.
      *
-     * @param string $owner
+     * @param  string $owner
      * @return string
      */
     public function compileTables(string $owner): string

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -1030,6 +1030,22 @@ class OracleGrammar extends Grammar
      */
     public function compileTables(string $owner): string
     {
+        return 'select lower(all_tab_comments.table_name)  as "name",
+                lower(all_tables.owner) as "schema",
+                sum(user_segments.bytes) as "size",
+                all_tab_comments.comments as "comments",
+                (select lower(value) from nls_database_parameters where parameter = \'NLS_SORT\') as "collation"
+            from all_tables
+                join all_tab_comments on all_tab_comments.table_name = all_tables.table_name
+                left join user_segments on user_segments.segment_name = all_tables.table_name
+            where all_tables.owner = \''.strtoupper($owner).'\'
+                and all_tab_comments.owner = \''.strtoupper($owner).'\'
+                and all_tab_comments.table_type in (\'TABLE\')
+            group by all_tab_comments.table_name, all_tables.owner, all_tables.num_rows,
+                all_tables.avg_row_len, all_tables.blocks, all_tab_comments.comments
+            order by all_tab_comments.table_name';
+    }
+    {
         return 'select all_tab_comments.table_name  as "name",
                 all_tables.owner as "schema",
                 coalesce(round(sum(user_segments.bytes) / 1024 / 1024, 2), 0) as "size",

--- a/src/Oci8/Schema/OracleBuilder.php
+++ b/src/Oci8/Schema/OracleBuilder.php
@@ -259,4 +259,18 @@ class OracleBuilder extends Builder
             $this->grammar->compileEnableForeignKeyConstraints($this->connection->getConfig('username'))
         );
     }
+
+    /**
+     * Get the tables that belong to the database.
+     *
+     * @return array
+     */
+    public function getTables()
+    {
+        return $this->connection->getPostProcessor()->processTables(
+            $this->connection->selectFromWriteConnection(
+                $this->grammar->compileTables($this->connection->getConfig('username'))
+            )
+        );
+    }
 }

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -1139,11 +1139,11 @@ class Oci8SchemaGrammarTest extends TestCase
     {
         $statement = $this->getGrammar()->compileTables('username');
 
-        $expected = 'select all_tab_comments.table_name  as "name",
-                all_tables.owner as "schema",
-                coalesce(round(sum(user_segments.bytes) / 1024 / 1024, 2), 0) as "size",
+        $expected = 'select lower(all_tab_comments.table_name)  as "name",
+                lower(all_tables.owner) as "schema",
+                sum(user_segments.bytes) as "size",
                 all_tab_comments.comments as "comments",
-                (select value from nls_database_parameters where parameter = \'nls_sort\') as "collation"
+                (select lower(value) from nls_database_parameters where parameter = \'NLS_SORT\') as "collation"
             from all_tables
                 join all_tab_comments on all_tab_comments.table_name = all_tables.table_name
                 left join user_segments on user_segments.segment_name = all_tables.table_name

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -1139,11 +1139,19 @@ class Oci8SchemaGrammarTest extends TestCase
     {
         $statement = $this->getGrammar()->compileTables('username');
 
-        $expected = 'select all_tab_comments.table_name  as "name"
-            from all_tab_comments
-                join all_tables on all_tab_comments.table_name = all_tables.table_name
-            where all_tab_comments.owner = \'USERNAME\'
+        $expected = 'select all_tab_comments.table_name  as "name",
+                all_tables.owner as "schema",
+                coalesce(round(sum(user_segments.bytes) / 1024 / 1024, 2), 0) as "size",
+                all_tab_comments.comments as "comments",
+                (select value from nls_database_parameters where parameter = \'nls_sort\') as "collation"
+            from all_tables
+                join all_tab_comments on all_tab_comments.table_name = all_tables.table_name
+                left join user_segments on user_segments.segment_name = all_tables.table_name
+            where all_tables.owner = \'USERNAME\'
+                and all_tab_comments.owner = \'USERNAME\'
                 and all_tab_comments.table_type in (\'TABLE\')
+            group by all_tab_comments.table_name, all_tables.owner, all_tables.num_rows,
+                all_tables.avg_row_len, all_tables.blocks, all_tab_comments.comments
             order by all_tab_comments.table_name';
 
         $this->assertEquals($expected, $statement);

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -1134,4 +1134,18 @@ class Oci8SchemaGrammarTest extends TestCase
 
         $this->assertEquals($expected, $statement);
     }
+
+    public function testCompileTables()
+    {
+        $statement = $this->getGrammar()->compileTables('username');
+
+        $expected = 'select all_tab_comments.table_name  as "name"
+            from all_tab_comments
+                join all_tables on all_tab_comments.table_name = all_tables.table_name
+            where all_tab_comments.owner = \'USERNAME\'
+                and all_tab_comments.table_type in (\'TABLE\')
+            order by all_tab_comments.table_name';
+
+        $this->assertEquals($expected, $statement);
+    }
 }


### PR DESCRIPTION
Hi, 

This pr is for implemente the missing method compileTables from laravel

```php
compileTables
```

i write the following query for get all table from database

```sql
SELECT all_tab_comments.table_name AS "name"
FROM all_tab_comments
         JOIN all_tables ON all_tab_comments.table_name = all_tables.table_name
WHERE all_tab_comments.owner = '{owner}'
  AND all_tab_comments.table_type IN ('TABLE')
ORDER BY all_tab_comments.table_name;
```
