### PR TITLE
[11.x] Test for existence of AuthServiceProvider before trying to use it

### DIFF
--- a/src/Oci8/Oci8ServiceProvider.php
+++ b/src/Oci8/Oci8ServiceProvider.php
@@ -26,9 +26,14 @@ class Oci8ServiceProvider extends ServiceProvider
             __DIR__.'/../config/oracle.php' => config_path('oracle.php'),
         ], 'oracle');
 
-        Auth::provider('oracle', function ($app, array $config) {
-            return new OracleUserProvider($app['hash'], $config['model']);
-        });
+        // Testing for existence of AuthServiceProvider before invoking it
+        // prevents errors when used with laravel-zero micro-framework which
+        // doesn't need auth.
+        if (class_exists('\Illuminate\Auth\AuthServiceProvider')) {
+            Auth::provider('oracle', function ($app, array $config) {
+                return new OracleUserProvider($app['hash'], $config['model']);
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This is a proposed fix for the error (see below) that I encountered while attempting to use yajra/laravel-oci8 with the Laravel Zero micro-framework.  The solution is to test whether the Laravel AuthServiceProvider class exists before attempting to use it.

```
   Illuminate\Contracts\Container\BindingResolutionException

  Target class [auth] does not exist.

  at vendor/illuminate/container/Container.php:940
    936▕
    937▕         try {
    938▕             $reflector = new ReflectionClass($concrete);
    939▕         } catch (ReflectionException $e) {
  ➜ 940▕             throw new BindingResolutionException("Target class [$concrete] does not exist.", 0, $e);

```

