### PR TITLE
fix: missing prefix on table alias

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -235,7 +235,7 @@ class OracleGrammar extends Grammar
         $tableName = $this->wrap($this->tablePrefix.$table, true);
         $segments = explode(' ', $table);
         if (count($segments) > 1) {
-            $tableName = $this->wrap($this->tablePrefix.$segments[0]).' '.$segments[1];
+            $tableName = $this->wrap($this->tablePrefix.$segments[0]).' '.$this->tablePrefix.$segments[1];
         }
 
         return $this->getSchemaPrefix().$tableName;

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -138,28 +138,20 @@ class Oci8QueryBuilderTest extends TestCase
         $this->assertEquals('select "FOO" as "BAR" from "USERS"', $builder->toSql());
     }
 
-    /**
-     * @TODO: Fix alias prefix and wrapping.
-     *      select * from "PREFIX_USERS" "PREFIX_PEOPLE"
-     */
     public function testAliasWithPrefix()
     {
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->select('*')->from('users as people');
-        $this->assertSame('select * from "PREFIX_USERS" people', $builder->toSql());
+        $this->assertSame('select * from "PREFIX_USERS" prefix_people', $builder->toSql());
     }
 
-    /**
-     * @TODO: Fix alias prefix
-     *      select * from "PREFIX_SERVICES" inner join "PREFIX_TRANSLATIONS" "PREFIX_T" on "PREFIX_T"."ITEM_ID" = "PREFIX_SERVICES"."ID"
-     */
     public function testJoinAliasesWithPrefix()
     {
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->select('*')->from('services')->join('translations AS t', 't.item_id', '=', 'services.id');
-        $this->assertSame('select * from "PREFIX_SERVICES" inner join "PREFIX_TRANSLATIONS" t on "PREFIX_T"."ITEM_ID" = "PREFIX_SERVICES"."ID"', $builder->toSql());
+        $this->assertSame('select * from "PREFIX_SERVICES" inner join "PREFIX_TRANSLATIONS" prefix_t on "PREFIX_T"."ITEM_ID" = "PREFIX_SERVICES"."ID"', $builder->toSql());
     }
 
     public function testBasicTableWrapping()


### PR DESCRIPTION
Hi.

Updated the OracleGrammar to correctly prefix both segments of table names when wrapping them.

This pr resolve #886 and i think resolve #875 too