### PR TITLE
fix: 🐛 multibyte object name causes error

### DIFF
--- a/src/Oci8/Eloquent/OracleEloquent.php
+++ b/src/Oci8/Eloquent/OracleEloquent.php
@@ -152,8 +152,8 @@ class OracleEloquent extends Model
             return $this->getTable().'.'.$this->getKeyName();
         }
 
-        $table = substr($this->getTable(), 0, $pos);
-        $dbLink = substr($this->getTable(), $pos);
+        $table = mb_substr($this->getTable(), 0, $pos);
+        $dbLink = mb_substr($this->getTable(), $pos);
 
         return $table.'.'.$this->getKeyName().$dbLink;
     }

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -447,7 +447,7 @@ class OracleGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        $index = substr($command->index, 0, $this->getMaxLength());
+        $index = mb_substr($command->index, 0, $this->getMaxLength());
 
         if ($type === 'index') {
             return "drop index {$index}";

--- a/src/Oci8/Schema/OracleAutoIncrementHelper.php
+++ b/src/Oci8/Schema/OracleAutoIncrementHelper.php
@@ -95,7 +95,7 @@ class OracleAutoIncrementHelper
     {
         $maxLength = $this->connection->getSchemaGrammar()->getMaxLength();
 
-        return substr($prefix.$table.'_'.$col.'_'.$type, 0, $maxLength);
+        return mb_substr($prefix.$table.'_'.$col.'_'.$type, 0, $maxLength);
     }
 
     /**

--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -83,14 +83,14 @@ class OracleBlueprint extends Blueprint
                     // if any part is longer than 2 chars, take one off
                     $len = strlen($parts[$i]);
                     if ($len > 2) {
-                        $parts[$i] = substr($parts[$i], 0, $len - 1);
+                        $parts[$i] = mb_substr($parts[$i], 0, $len - 1);
                     }
                 }
 
                 $index = implode('_', $parts);
             }
         } else {
-            $index = substr($this->table, 0, 10).'_comp_'.str_replace('.', '_', microtime(true));
+            $index = mb_substr($this->table, 0, 10).'_comp_'.str_replace('.', '_', microtime(true));
         }
 
         return $index;

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -811,7 +811,7 @@ class Oci8QueryBuilderTest extends TestCase
         $bindings = str_repeat('?, ', 1000);
         $expected = sprintf(
             'select * from "USERS" where ("ID" in (%s) or "ID" in (?))',
-            substr($bindings, 0, 2998)
+            mb_substr($bindings, 0, 2998)
         );
         $this->assertEquals($expected, $builder->toSql());
         $this->assertEquals(range(1, 1001), $builder->getBindings());
@@ -821,7 +821,7 @@ class Oci8QueryBuilderTest extends TestCase
         $bindings = str_repeat('?, ', 1000);
         $expected = sprintf(
             'select * from "USERS" where ("ID" in (%s) or "ID" in (?)) and "ID" = ?',
-            substr($bindings, 0, 2998)
+            mb_substr($bindings, 0, 2998)
         );
         $this->assertEquals($expected, $builder->toSql());
     }
@@ -833,7 +833,7 @@ class Oci8QueryBuilderTest extends TestCase
         $bindings = str_repeat('?, ', 1000);
         $expected = sprintf(
             'select * from "USERS" where ("ID" not in (%s) and "ID" not in (?))',
-            substr($bindings, 0, 2998)
+            mb_substr($bindings, 0, 2998)
         );
         $this->assertEquals($expected, $builder->toSql());
         $this->assertEquals(range(1, 1001), $builder->getBindings());
@@ -843,7 +843,7 @@ class Oci8QueryBuilderTest extends TestCase
         $bindings = str_repeat('?, ', 1000);
         $expected = sprintf(
             'select * from "USERS" where ("ID" not in (%s) and "ID" not in (?)) and "ID" = ?',
-            substr($bindings, 0, 2998)
+            mb_substr($bindings, 0, 2998)
         );
         $this->assertEquals($expected, $builder->toSql());
     }


### PR DESCRIPTION
## Context
Multi byte character handling

- Oracle 12.2.0.2.1 EE 
- laracel-oci [v11.6.2](https://github.com/yajra/laravel-oci8/releases/tag/v11.6.2)

## Problem
Oracle database allows multi byte characters in object names such as sequences, so if I try to use multi byte characters in sequence names, an exception will be thrown due to the handling of multi byte characters.

```json
{
    "message": "ORA-01756: quoted string not properly terminated (Connection: oracle, SQL: select * from all_sequences where sequence_name=upper('PRF_商品マスタ_商品コ�') and sequence_owner=upper(user))",
    "context": {
        "exception": {
            "class": "Illuminate\\Database\\QueryException",
            "message": "ORA-01756: quoted string not properly terminated (Connection: oracle, SQL: select * from all_sequences where sequence_name=upper('PRF_商品マスタ_商品コ�') and sequence_owner=upper(user))",
            "code": 0,
            "file": "/app/vendor/laravel/framework/src/Illuminate/Database/Connection.php:825",
            "previous": {
                "class": "Yajra\\Pdo\\Oci8\\Exceptions\\Oci8Exception",
                "message": "ORA-01756: quoted string not properly terminated",
                "code": 0,
                "file": "/app/vendor/yajra/laravel-pdo-via-oci8/src/Pdo/Oci8.php:328"
            }
        }
    },
    "level": 400,
    "level_name": "ERROR",
    "channel": "local",
    "datetime": "2024-12-15T04:22:08.339346+09:00",
    "extra": {}
}
```

I know it should not use multi byte character in any object name but sadly my recent work environment using multi byte object name.


## How to reproduce

1. Set oracle server character set to `JA16SJISTILDE` 

2. Create migration file like below
 
```bash
$ php artisan make:migration create_multibyte_object_name
```

```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Support\Facades\Schema;
use Yajra\Oci8\Schema\OracleBlueprint;

return new class () extends Migration {
    public function up(): void
    {
        Schema::create('PRF_商品マスタ', function (OracleBlueprint $table) {
            $table->string('商品コード', 10);
            $table->primary('商品コード', 'PK_PRF_商品マスタ');
        });
    }

    public function down(): void
    {
        Schema::dropIfExists('PRF_商品マスタ');
    }

    public function getConnection()
    {
        return 'oracle';
    }
};
```

3. php artisan migrate
4. php artisan migrate:rollback -> above error occur

## Solution
- Use `mb_substr` instead of `substr`. Because it handles both unicode character and ascii character properly.