### PR TITLE
fix: OracleGrammar::compileDropAllTables method to ignore secondary objects.

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -377,7 +377,7 @@ class OracleGrammar extends Grammar
     public function compileDropAllTables()
     {
         return 'BEGIN
-            FOR c IN (SELECT table_name FROM user_tables) LOOP
+            FOR c IN (SELECT table_name FROM user_tables WHERE secondary = \'N\') LOOP
             EXECUTE IMMEDIATE (\'DROP TABLE "\' || c.table_name || \'" CASCADE CONSTRAINTS\');
             END LOOP;
 


### PR DESCRIPTION

Update the `OracleGrammar::compileDropAllTables` method to ignore secondary objects.

PR resolves issue [#896](https://github.com/yajra/laravel-oci8/issues/896).

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
