### PR TITLE
Fix ORA-00942  when try to drop any table

### DIFF
--- a/src/Oci8/Schema/OracleBuilder.php
+++ b/src/Oci8/Schema/OracleBuilder.php
@@ -92,7 +92,9 @@ class OracleBuilder extends Builder
     public function drop($table): void
     {
         $this->helper->dropAutoIncrementObjects($table);
-        $this->ctxDdlPreferences->dropPreferencesByTable($table);
+        if ($this->ctxDdlPreferences->checkIfCtxsysIsEnabled()) {
+            $this->ctxDdlPreferences->dropPreferencesByTable($table);
+        }
         parent::drop($table);
     }
 
@@ -113,7 +115,9 @@ class OracleBuilder extends Builder
     public function dropIfExists($table): void
     {
         $this->helper->dropAutoIncrementObjects($table);
-        $this->ctxDdlPreferences->dropPreferencesByTable($table);
+        if ($this->ctxDdlPreferences->checkIfCtxsysIsEnabled()) {
+            $this->ctxDdlPreferences->dropPreferencesByTable($table);
+        }
         parent::dropIfExists($table);
     }
 

--- a/src/Oci8/Schema/OraclePreferences.php
+++ b/src/Oci8/Schema/OraclePreferences.php
@@ -111,4 +111,18 @@ class OraclePreferences
 
         $this->connection->statement($sqlDropAllPreferences);
     }
+
+    /**
+     * Check if CTXSYS is enabled.
+     */
+    public function checkIfCtxsysIsEnabled(): bool
+    {
+        $results = $this->connection->select("SELECT USERNAME FROM all_users WHERE username = 'CTXSYS'");
+
+        if (empty($results)) {
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Hi yajra,

this PR implements a check to verify if the CTXSYS user exists in the database before calling any statement that requires it.

This should fix the following issue:

[[BUG] ORA-00942: when try to drop any table](https://github.com/yajra/laravel-oci8/issues/916)
[Oracle Text Search context missing in gvenzl/oracle-free slim Docker images causes tests and migration failures](https://github.com/yajra/laravel-oci8/issues/917)