### PR TITLE
Fix error when call php artisan db:show 

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -126,7 +126,7 @@ class Oci8Connection extends Connection
         $versionQuery->execute();
         $version = $versionQuery->fetch(PDO::FETCH_OBJ);
 
-        return $version->banner_full;
+        return $version->banner;
     }
 
     /**

--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -118,6 +118,18 @@ class Oci8Connection extends Connection
     }
 
     /**
+     * Get the server version for the connection.
+     */
+    public function getServerVersion(): string
+    {
+        $versionQuery = $this->getPdo()->prepare('SELECT BANNER FROM v$version');
+        $versionQuery->execute();
+        $version = $versionQuery->fetch(PDO::FETCH_OBJ);
+
+        return $version->banner_full;
+    }
+
+    /**
      * Get a new query builder instance.
      */
     public function query(): QueryBuilder

--- a/tests/Database/Oci8ConnectionTest.php
+++ b/tests/Database/Oci8ConnectionTest.php
@@ -101,6 +101,14 @@ class Oci8ConnectionTest extends TestCase
         $this->assertFalse($connection->dropSequence(null));
     }
 
+    public function test_get_server_version()
+    {
+        $connection = m::mock(Oci8Connection::class);
+        $connection->shouldReceive('getServerVersion')->withNoArgs()->once()->andReturn('Oracle Database');
+
+        $this->assertSame('Oracle Database', $connection->getServerVersion());
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;


### PR DESCRIPTION
Hi yajra,

this PR implements the missing getServerVersion function, resolving the issue encountered when running the `php artisan db:show` command.