### PR TITLE
fix: log query time to be compatible with laravel logging

### DIFF
--- a/src/Oci8/Query/Processors/OracleProcessor.php
+++ b/src/Oci8/Query/Processors/OracleProcessor.php
@@ -33,7 +33,7 @@ class OracleProcessor extends Processor
         $statement->bindParam($parameter, $id, PDO::PARAM_INT, -1);
         $statement->execute();
 
-        $connection->logQuery($sql, $values, $start);
+        $connection->logQuery($sql, $values, $this->getElapsedTime($start));
 
         return $id;
     }
@@ -97,6 +97,17 @@ class OracleProcessor extends Processor
     }
 
     /**
+     * Get the elapsed time since a given starting point.
+     *
+     * @param  int  $start
+     * @return float
+     */
+    protected function getElapsedTime($start)
+    {
+        return round((microtime(true) - $start) * 1000, 2);
+    }
+
+    /**
      * Get PDO Type depending on value.
      */
     private function getPdoType(mixed $value): int
@@ -145,7 +156,7 @@ class OracleProcessor extends Processor
             return 0;
         }
 
-        $connection->logQuery($sql, $values, $start);
+        $connection->logQuery($sql, $values, $this->getElapsedTime($start));
 
         return $id;
     }


### PR DESCRIPTION
Instead of get the elapsed time the code fixed was getting only the start time. This PR fixes that.