### PR TITLE
Fix: Remove unnecessary wrapping of sequence name in drop method

### DIFF
--- a/src/Oci8/Schema/Sequence.php
+++ b/src/Oci8/Schema/Sequence.php
@@ -28,8 +28,6 @@ class Sequence
 
     public function drop(string $name): bool
     {
-        $name = $this->wrap($name);
-
         if (! $this->exists($name)) {
             return true;
         }


### PR DESCRIPTION
Hi Yajra,

This PR addresses an issue that occurs when a prefix is set in the configuration and an attempt is made to drop a sequence:

```php
'prefix' => env('DB_PREFIX', ''),
```

Inside src/Oci8/Schema/Sequence.php, in the drop function, the `$name` parameter is already prefixed 
by the `dropAutoIncrementObjects` method in src/Oci8/Schema/OracleAutoIncrementHelper.php.

As a result, the line `$name = $this->wrap($name);` causes the sequence name to be double-prefixed, which prevents it from being deleted correctly.

so the  `$name = $this->wrap($name);` couse the sequence to be double prefixed and not deleted
```php
  public function drop(string $name): bool
  {
      $name = $this->wrap($name);

      if (! $this->exists($name)) {
          return true;
      }
```

The steps to reproduce the error are as follows: set a prefix, create a table with an id column, run the migration, rollback, and then run the migration again.

This causes the following error:
```sql
ORA-00955: name is already used by an existing object
```