### PR TITLE
Fix Migration comment not working, ORA-00904

### DIFF
--- a/src/Oci8/Schema/Comment.php
+++ b/src/Oci8/Schema/Comment.php
@@ -3,6 +3,7 @@
 namespace Yajra\Oci8\Schema;
 
 use Illuminate\Database\Schema\Grammars\Grammar;
+use Illuminate\Support\Str;
 use Yajra\Oci8\OracleReservedWords;
 
 class Comment extends Grammar
@@ -46,7 +47,7 @@ class Comment extends Grammar
      */
     protected function wrapValue($value): string
     {
-        return $this->isReserved($value) ? parent::wrapValue($value) : $value;
+        return $this->isReserved($value) ? Str::upper(trim(parent::wrapValue($value))) : $value;
     }
 
     /**


### PR DESCRIPTION
Hi yajra,

I investigated the issue and found the cause.
When creating a comment on a reserved word, the `parent::wrapValue($value)` function adds double quotes around `$value`.

This leads to the ORA-00904 error, because with double quotes, the column name must match exactly as it was created.

This fix [[BUG] Migration comment not working, ORA-00904](https://github.com/yajra/laravel-oci8/issues/910)