### PR TITLE
Fix duplicate ORDER BY in Oracle lock queries

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -124,7 +124,7 @@ class OracleGrammar extends Grammar
              * - If LIMIT is set, we want ORDER BY for consistent pagination, but
              *   we still avoid appending ORDER BY if it's already present in $sql.
              */
-            $appendOrder = !empty($orderSql) && !$hasOrderInSql;
+            $appendOrder = ! empty($orderSql) && ! $hasOrderInSql;
 
             if ($appendOrder) {
                 $sql .= " {$orderSql}";

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -110,8 +110,12 @@ class OracleGrammar extends Grammar
 
             // Handle ORDER BY placement based on query structure
             if (isset($query->limit)) {
-                // With limit: ORDER BY is already in inner query, only add lock
-                $sql .= " {$lockSql}";
+                // With limit: Add lock and ORDER BY clause if present
+                if (!empty($orderSql)) {
+                    $sql .= " {$lockSql} {$orderSql}";
+                } else {
+                    $sql .= " {$lockSql}";
+                }
             } else {
                 // Without limit: Check if ORDER BY already exists to prevent duplication
                 if (!empty($orderSql) && stripos($sql, 'order by') === false) {

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -105,7 +105,7 @@ class OracleGrammar extends Grammar
         }
 
         if (isset($query->lock)) {
-            $sql .= $this->compileLock($query, $query->lock);
+            $sql .= ' '.$this->compileLock($query, $query->lock);
             $orderSql = $this->compileOrders($query, $query->orders);
 
             /**

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3272,7 +3272,7 @@ class Oci8QueryBuilderTest extends TestCase
 
         // Should contain ORDER BY only once (the bug would cause 2)
         $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
-        $this->assertStringContainsString('order by', strtolower($sql));
-        $this->assertStringContainsString('for update', strtolower($sql));
+        $this->assertStringContainsString('order by', strtolower((string) $sql));
+        $this->assertStringContainsString('for update', strtolower((string) $sql));
     }
 }

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3225,4 +3225,54 @@ class Oci8QueryBuilderTest extends TestCase
 
         return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
     }
+
+    public function test_order_by_not_duplicated_with_lock()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name')->lock();
+
+        $sql = $builder->toSql();
+
+        // Should contain ORDER BY only once
+        $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
+        $this->assertStringContainsString('order by', strtolower((string) $sql));
+        $this->assertStringContainsString('for update', strtolower((string) $sql));
+    }
+
+    public function test_order_by_not_duplicated_with_limit_and_lock()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name')->limit(10)->lock();
+
+        $sql = $builder->toSql();
+
+        // Should contain ORDER BY only once
+        $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
+        $this->assertStringContainsString('order by', strtolower((string) $sql));
+    }
+
+    public function test_order_by_appended_when_not_present()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+
+        $sql = $builder->toSql();
+
+        $this->assertStringContainsString('order by "name" asc', strtolower((string) $sql));
+    }
+
+    public function test_order_by_duplication_prevention_works_correctly()
+    {
+        // This test demonstrates that the ORDER BY duplication prevention
+        // successfully prevents duplicate ORDER BY when both limit and lock are used
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name')->limit(10)->lock();
+
+        $sql = $builder->toSql();
+
+        // Should contain ORDER BY only once (the bug would cause 2)
+        $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
+        $this->assertStringContainsString('order by', strtolower($sql));
+        $this->assertStringContainsString('for update', strtolower($sql));
+    }
 }


### PR DESCRIPTION
Problem:
  - Oracle queries with lock() and orderBy() generated duplicate ORDER BY clauses
  - Example: "SELECT * FROM table ORDER BY col FOR UPDATE NOWAIT ORDER BY col"
  - Caused SQL syntax errors when using lock without limit

  Root Cause:
  - Original logic only removed ORDER BY from components when both lock AND limit were present
  - Without limit, ORDER BY was included in components AND manually appended in lock section
  - This resulted in "ORDER BY ... FOR UPDATE NOWAIT ORDER BY ..." pattern

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
