### PR TITLE
Fix duplicate ORDER BY clauses when using lock() without limit() (for 11.x)

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -102,7 +102,30 @@ class OracleGrammar extends Grammar
         }
 
         if (isset($query->lock)) {
-            $sql .= ' '.$this->compileLock($query, $query->lock).' '.$this->compileOrders($query, $query->orders);
+            $sql .= ' '.$this->compileLock($query, $query->lock);
+            $orderSql = $this->compileOrders($query, $query->orders);
+
+            /**
+             * Check if the original SQL already contains an ORDER BY clause.
+             */
+            $hasOrderInSql = stripos($sql, 'order by') !== false;
+
+            /**
+             * Determine whether to append the ORDER BY clause:
+             * - Append ORDER BY only if $orderSql is not empty
+             * - Append ORDER BY only if the original SQL does NOT already contain ORDER BY
+             *
+             * This prevents duplicate ORDER BY clauses causing SQL syntax errors.
+             *
+             * Note:
+             * - If LIMIT is set, we want ORDER BY for consistent pagination, but
+             *   we still avoid appending ORDER BY if it's already present in $sql.
+             */
+            $appendOrder = ! empty($orderSql) && ! $hasOrderInSql;
+
+            if ($appendOrder) {
+                $sql .= " {$orderSql}";
+            }
         }
 
         $query->columns = $original;

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3197,4 +3197,54 @@ class Oci8QueryBuilderTest extends TestCase
 
         return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
     }
+
+    public function test_order_by_not_duplicated_with_lock()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name')->lock();
+
+        $sql = $builder->toSql();
+
+        // Should contain ORDER BY only once
+        $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
+        $this->assertStringContainsString('order by', strtolower((string) $sql));
+        $this->assertStringContainsString('for update', strtolower((string) $sql));
+    }
+
+    public function test_order_by_not_duplicated_with_limit_and_lock()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name')->limit(10)->lock();
+
+        $sql = $builder->toSql();
+
+        // Should contain ORDER BY only once
+        $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
+        $this->assertStringContainsString('order by', strtolower((string) $sql));
+    }
+
+    public function test_order_by_appended_when_not_present()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+
+        $sql = $builder->toSql();
+
+        $this->assertStringContainsString('order by "name" asc', strtolower((string) $sql));
+    }
+
+    public function test_order_by_duplication_prevention_works_correctly()
+    {
+        // This test demonstrates that the ORDER BY duplication prevention
+        // successfully prevents duplicate ORDER BY when both limit and lock are used
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name')->limit(10)->lock();
+
+        $sql = $builder->toSql();
+
+        // Should contain ORDER BY only once (the bug would cause 2)
+        $this->assertEquals(1, substr_count(strtolower((string) $sql), 'order by'));
+        $this->assertStringContainsString('order by', strtolower((string) $sql));
+        $this->assertStringContainsString('for update', strtolower((string) $sql));
+    }
 }


### PR DESCRIPTION
This is a backport of the fix introduced in [#930.](https://github.com/yajra/laravel-oci8/pull/930)
The change ensures the query does not contain multiple ORDER BY clauses and includes tests to cover this case.
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
