### PR TITLE
fix: Fix issue where db_prefix is not considered in max length

### DIFF
--- a/src/Oci8/Schema/OracleAutoIncrementHelper.php
+++ b/src/Oci8/Schema/OracleAutoIncrementHelper.php
@@ -66,7 +66,7 @@ class OracleAutoIncrementHelper
      */
     private function createObjectName(string $table, string $col, string $type): string
     {
-        $maxLength = $this->connection->getMaxLength();
+        $maxLength = $this->connection->getMaxLength() - strlen($this->connection->getTablePrefix());
 
         return $this->connection
             ->getQueryGrammar()


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
createObjectName does not accommodate DB_PREFIX length like the previous versions did causing name identifier too long errors for long sequence / trigger names. This PR fixes it.

