### PR TITLE
CI/CD: Update Semantic Release as manual run

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,10 +1,7 @@
 name: Semantic Releases
 
 on:
-  push:
-    branches:
-      - master
-      - '*.x'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,5 +1,6 @@
 {
     "branches": [
+        "main",
         "master",
         "*.x"
     ],


### PR DESCRIPTION
This pull request updates the CI/CD workflow to allow Semantic Release to be triggered manually using workflow_dispatch.