### PR TITLE
Improve ci by running test in 21c too

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,20 +13,22 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    services:
-      oracle:
-        image: deepdiver/docker-oracle-xe-11g:2.0
-        ports:
-          - 49160:22
-          - 1521:1521
-
     strategy:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
         stability: [prefer-stable]
+        oracle: [11g, 21c]
 
-    name: PHP ${{ matrix.php }} - STABILITY ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - ORACLE ${{ matrix.oracle }} - STABILITY ${{ matrix.stability }}
+
+    services:
+      oracle:
+        image: ${{ matrix.oracle == '11g' && 'deepdiver/docker-oracle-xe-11g:2.0' || 'container-registry.oracle.com/database/express:21.3.0-xe' }}
+        ports:
+          - 1521:1521
+        env:
+          ORACLE_PWD: ${{ matrix.oracle == '21c' && 'oracle' || '' }}
 
     steps:
       - name: Checkout code
@@ -48,4 +50,9 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: |
+          if [ "${{ matrix.oracle }}" = "21c" ]; then
+            SERVER_VERSION=12c vendor/bin/phpunit
+          else
+            vendor/bin/phpunit
+          fi

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -84,6 +84,7 @@ abstract class TestCase extends BaseTestCase
             'username' => 'system',
             'password' => 'oracle',
             'port' => 1521,
+            'server_version' => getenv('SERVER_VERSION') ? getenv('SERVER_VERSION') : '11g',
         ]);
     }
 


### PR DESCRIPTION
Since some functionality now requires at least Oracle 12c, I updated the CI configuration to also test using a 21c container, while retaining the existing 11g container.

In 21c tests, server_version is set to 12c because the code checks for this version explicitly.

Appreciate your time, keep up the good work!


