### PR TITLE
feat: use COLLATE BINARY_CI in where like for 12c+

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -729,6 +729,10 @@ class OracleGrammar extends Grammar
 
         $operator = str_replace('?', '??', $where['operator']);
 
+        if ($query->getConnection()->getConfig('server_version') == '12c') {
+            return $this->wrap($where['column']).' '.$operator.' '.$value.' COLLATE BINARY_CI';
+        }
+
         return 'upper('.$this->wrap($where['column']).') '.$operator.' upper('.$value.')';
     }
 }

--- a/tests/Database/DatabaseTestCase.php
+++ b/tests/Database/DatabaseTestCase.php
@@ -34,5 +34,7 @@ abstract class DatabaseTestCase extends TestCase
         $connection = $app['config']->get('database.default');
 
         $this->driver = $app['config']->get("database.connections.$connection.driver");
+
+        $app['config']->set('database.connections.oracle.server_version', getenv('SERVER_VERSION') ? getenv('SERVER_VERSION') : '11g');
     }
 }

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3283,7 +3283,12 @@ class Oci8QueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereLike('id', '1', false);
-        $this->assertSame('select * from "USERS" where upper("ID") like upper(?)', $builder->toSql());
+        if($this->getConnection()->getConfig('server_version') === '12c') {
+            $this->assertSame('select * from "USERS" where "ID" like ? COLLATE BINARY_CI', $builder->toSql());
+        } else {
+            $this->assertSame('select * from "USERS" where upper("ID") like upper(?)', $builder->toSql());
+        }
+
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -3293,12 +3298,20 @@ class Oci8QueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotLike('id', '1');
-        $this->assertSame('select * from "USERS" where upper("ID") not like upper(?)', $builder->toSql());
+        if($this->getConnection()->getConfig('server_version') === '12c') {
+            $this->assertSame('select * from "USERS" where "ID" not like ? COLLATE BINARY_CI', $builder->toSql());
+        } else {
+            $this->assertSame('select * from "USERS" where upper("ID") not like upper(?)', $builder->toSql());
+        }
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotLike('id', '1', false);
-        $this->assertSame('select * from "USERS" where upper("ID") not like upper(?)', $builder->toSql());
+        if($this->getConnection()->getConfig('server_version') === '12c') {
+            $this->assertSame('select * from "USERS" where "ID" not like ? COLLATE BINARY_CI', $builder->toSql());
+        } else {
+            $this->assertSame('select * from "USERS" where upper("ID") not like upper(?)', $builder->toSql());
+        }
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
The UPPER() function in the generated SQL is currently applied to columns that are already passed as uppercase. 

This redundant usage negatively impacts Oracle's execution plan and overall query performance.

This commit removes the unnecessary UPPER() calls in the generated SQL since the column is already uppercase, improving performance for WHERE LIKE queries without changing query behavior.

Thank you for reviewing this change.
