### PR TITLE
feat: implement index renaming in OracleGrammar

### DIFF
--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -495,6 +495,18 @@ class OracleGrammar extends Grammar
     }
 
     /**
+     * Compile a rename index command.
+     */
+    public function compileRenameIndex(Blueprint $blueprint, Fluent $command): string
+    {
+        return sprintf(
+            'alter index %s rename to %s',
+            $this->wrap($command->from),
+            $this->wrap($command->to)
+        );
+    }
+
+    /**
      * Create the column definition for a char type.
      */
     protected function typeChar(Fluent $column): string

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -777,6 +777,20 @@ class Oci8SchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "PREFIX_USERS" rename to "PREFIX_FOO"', $statements[0]);
     }
 
+    public function test_rename_index()
+    {
+        $conn = $this->getConnection();
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->renameIndex('users_email_index', 'users_email_address_index');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter index "USERS_EMAIL_INDEX" rename to "USERS_EMAIL_ADDRESS_INDEX"',
+            $statements[0]
+        );
+    }
+
     public function test_adding_primary_key()
     {
         $conn = $this->getConnection();

--- a/tests/Functional/Compatibility/SchemaTest.php
+++ b/tests/Functional/Compatibility/SchemaTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional\Compatibility;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\Oci8\Tests\TestCase;
+
+class SchemaTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        if (Schema::hasTable('rename_index_table')) {
+            Schema::drop('rename_index_table');
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_can_rename_index()
+    {
+        Schema::create('rename_index_table', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('name')->index();
+        });
+
+        Schema::table('rename_index_table', function (Blueprint $table) {
+            $table->renameIndex('rename_index_table_name_index', 'rename_index_table_name_idx');
+        });
+
+        $indexes = array_column(Schema::getIndexes('rename_index_table'), 'name');
+
+        $this->assertContains('rename_index_table_name_idx', $indexes);
+        $this->assertNotContains('rename_index_table_name_index', $indexes);
+    }
+}


### PR DESCRIPTION
Implement index renaming in SchemaBuilder eg.:
```php
Schema::table('rename_index_table', function (Blueprint $table) {
      $table->renameIndex('rename_index_table_name_index', 'rename_index_table_name_idx');
});
```

Thank you for reviewing!