### PR TITLE
fix: move binary_ci in whereLike to 12cR2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ To set this version use `DB_SERVER_VERSION` env variable or change `server_versi
 This is the baseline, if no version is set, this version is assumed.
 ### 12c
 - Use fetch/offset where possible instead of rownumber.
-- In whereLike use `binary ci` for case insensitivity. ([#945](https://github.com/yajra/laravel-oci8/pull/945))
 - Use identity instead of seqvence/trigger for ids when using laravel's scheme builder. ([#944](https://github.com/yajra/laravel-oci8/pull/944))
+
+### 12cR2
+- In whereLike use `binary ci` for case insensitivity. ([#945](https://github.com/yajra/laravel-oci8/pull/945))
 
 ## Oracle Max Name Length
 

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -787,7 +787,7 @@ class OracleGrammar extends Grammar
 
         $operator = str_replace('?', '??', $where['operator']);
 
-        if ($query->getConnection()->isVersionAboveOrEqual('12c')) {
+        if ($query->getConnection()->isVersionAboveOrEqual('12cR2')) {
             return $this->wrap($where['column']).' '.$operator.' '.$value.' COLLATE BINARY_CI';
         }
 

--- a/tests/Database/Oci8ConnectionTest.php
+++ b/tests/Database/Oci8ConnectionTest.php
@@ -129,6 +129,19 @@ class Oci8ConnectionTest extends TestCase
         $this->assertTrue($connection->isVersionBelowOrEqual('19c'));
     }
 
+    public function test_compare_configured_12cr2_server_version()
+    {
+        $connection = m::mock(Oci8Connection::class)->makePartial();
+        $connection->shouldReceive('getConfig')->with('server_version')->times(6)->andReturn('12cR2');
+
+        $this->assertTrue($connection->isVersionAbove('11g'));
+        $this->assertTrue($connection->isVersionAbove('12c'));
+        $this->assertTrue($connection->isVersionAboveOrEqual('12cR2'));
+        $this->assertFalse($connection->isVersionBelow('11g'));
+        $this->assertTrue($connection->isVersionBelow('19c'));
+        $this->assertTrue($connection->isVersionBelowOrEqual('12cR2'));
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3357,7 +3357,7 @@ class Oci8QueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereLike('id', '1', false);
-        if ($this->getConnection()->isVersionAboveOrEqual('12c')) {
+        if ($this->getConnection()->isVersionAboveOrEqual('12cR2')) {
             $this->assertSame('select * from "USERS" where "ID" like ? COLLATE BINARY_CI', $builder->toSql());
         } else {
             $this->assertSame('select * from "USERS" where upper("ID") like upper(?)', $builder->toSql());
@@ -3372,7 +3372,7 @@ class Oci8QueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotLike('id', '1');
-        if ($this->getConnection()->isVersionAboveOrEqual('12c')) {
+        if ($this->getConnection()->isVersionAboveOrEqual('12cR2')) {
             $this->assertSame('select * from "USERS" where "ID" not like ? COLLATE BINARY_CI', $builder->toSql());
         } else {
             $this->assertSame('select * from "USERS" where upper("ID") not like upper(?)', $builder->toSql());
@@ -3381,7 +3381,7 @@ class Oci8QueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotLike('id', '1', false);
-        if ($this->getConnection()->isVersionAboveOrEqual('12c')) {
+        if ($this->getConnection()->isVersionAboveOrEqual('12cR2')) {
             $this->assertSame('select * from "USERS" where "ID" not like ? COLLATE BINARY_CI', $builder->toSql());
         } else {
             $this->assertSame('select * from "USERS" where upper("ID") not like upper(?)', $builder->toSql());


### PR DESCRIPTION
Move binary_ci to a separate version.

This fixes this issue: #979.

Thank you for reviewing!