### PR TITLE
Feature: Add missing miscellaneous functions to schemabuilder

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -23,6 +23,11 @@ class OracleGrammar extends Grammar
     use OracleReservedWords;
 
     /**
+     * Indicates whether the truncate statement should cascade.
+     */
+    protected static bool $cascadeTruncate = false;
+
+    /**
      * The keyword identifier wrapper format.
      */
     protected string $wrapper = '%s';
@@ -389,7 +394,27 @@ class OracleGrammar extends Grammar
      */
     public function compileTruncate(Builder $query): array
     {
-        return ['truncate table '.$this->wrapTable($query->from) => []];
+        $cascade = static::$cascadeTruncate && $query->getConnection()->isVersionAboveOrEqual('12c')
+            ? ' cascade'
+            : '';
+
+        return ['truncate table '.$this->wrapTable($query->from).$cascade => []];
+    }
+
+    /**
+     * Enable or disable the "cascade" option when compiling the truncate statement.
+     */
+    public static function cascadeOnTruncate(bool $value = true): void
+    {
+        static::$cascadeTruncate = $value;
+    }
+
+    /**
+     * @deprecated use cascadeOnTruncate
+     */
+    public static function cascadeOnTrucate(bool $value = true): void
+    {
+        self::cascadeOnTruncate($value);
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -427,7 +427,13 @@ class OracleGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command): string
     {
-        return "create index {$command->index} on ".$this->wrapTable($blueprint).' ( '.$this->columnize($command->columns).' )';
+        $sql = "create index {$command->index} on ".$this->wrapTable($blueprint).' ( '.$this->columnize($command->columns).' )';
+
+        if ($command->online) {
+            $sql .= ' online';
+        }
+
+        return $sql;
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -153,6 +153,8 @@ class OracleGrammar extends Grammar
             if (! is_null($foreign->onDelete)) {
                 $sql .= " on delete {$foreign->onDelete}";
             }
+
+            $sql = $this->appendDeferrableClause($foreign, $sql);
         }
 
         return $sql;
@@ -379,7 +381,7 @@ class OracleGrammar extends Grammar
                 $sql .= " on delete {$command->onDelete}";
             }
 
-            return $sql;
+            return $this->appendDeferrableClause($command, $sql);
         }
 
         return null;
@@ -390,7 +392,22 @@ class OracleGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command): string
     {
-        return 'alter table '.$this->wrapTable($blueprint)." add constraint {$command->index} unique ( ".$this->columnize($command->columns).' )';
+        $sql = 'alter table '.$this->wrapTable($blueprint)." add constraint {$command->index} unique ( ".$this->columnize($command->columns).' )';
+
+        return $this->appendDeferrableClause($command, $sql);
+    }
+
+    protected function appendDeferrableClause(Fluent $command, string $sql): string
+    {
+        if (! is_null($command->deferrable)) {
+            $sql .= $command->deferrable ? ' deferrable' : ' not deferrable';
+        }
+
+        if ($command->deferrable && ! is_null($command->initiallyImmediate)) {
+            $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
+        }
+
+        return $sql;
     }
 
     /**

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -155,6 +155,7 @@ class OracleGrammar extends Grammar
             }
 
             $sql = $this->appendDeferrableClause($foreign, $sql);
+            $sql = $this->appendNotValidClause($foreign, $sql);
         }
 
         return $sql;
@@ -381,7 +382,9 @@ class OracleGrammar extends Grammar
                 $sql .= " on delete {$command->onDelete}";
             }
 
-            return $this->appendDeferrableClause($command, $sql);
+            $sql = $this->appendDeferrableClause($command, $sql);
+
+            return $this->appendNotValidClause($command, $sql);
         }
 
         return null;
@@ -405,6 +408,15 @@ class OracleGrammar extends Grammar
 
         if ($command->deferrable && ! is_null($command->initiallyImmediate)) {
             $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
+        }
+
+        return $sql;
+    }
+
+    protected function appendNotValidClause(Fluent $command, string $sql): string
+    {
+        if (! is_null($command->notValid) && $command->notValid) {
+            $sql .= ' enable novalidate';
         }
 
         return $sql;

--- a/src/Oci8/Schema/Grammars/OracleGrammar.php
+++ b/src/Oci8/Schema/Grammars/OracleGrammar.php
@@ -52,7 +52,9 @@ class OracleGrammar extends Grammar
     {
         $columns = implode(', ', $this->getColumns($blueprint));
 
-        $sql = 'create table '.$this->wrapTable($blueprint)." ( $columns";
+        $create = $blueprint->temporary ? 'create global temporary table ' : 'create table ';
+
+        $sql = $create.$this->wrapTable($blueprint)." ( $columns";
 
         /*
          * To be able to name the primary/foreign keys when the table is
@@ -65,6 +67,10 @@ class OracleGrammar extends Grammar
         $sql .= $this->addPrimaryKeys($blueprint);
 
         $sql .= ' )';
+
+        if ($blueprint->temporary) {
+            $sql .= ' on commit preserve rows';
+        }
 
         return $sql;
     }

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3120,6 +3120,40 @@ class Oci8QueryBuilderTest extends TestCase
         $builder->from('users')->truncate();
     }
 
+    public function test_truncate_method_with_cascade()
+    {
+        OracleGrammar::cascadeOnTruncate();
+
+        try {
+            $builder = new Builder(
+                $connection = $this->getConnection(serverVersion: '12c'),
+                new OracleGrammar($connection),
+                m::mock(OracleProcessor::class)
+            );
+            $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "USERS" cascade', []);
+            $builder->from('users')->truncate();
+        } finally {
+            OracleGrammar::cascadeOnTruncate(false);
+        }
+    }
+
+    public function test_truncate_method_with_cascade_on_unsupported_version()
+    {
+        OracleGrammar::cascadeOnTruncate();
+
+        try {
+            $builder = new Builder(
+                $connection = $this->getConnection(serverVersion: '11g'),
+                new OracleGrammar($connection),
+                m::mock(OracleProcessor::class)
+            );
+            $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "USERS"', []);
+            $builder->from('users')->truncate();
+        } finally {
+            OracleGrammar::cascadeOnTruncate(false);
+        }
+    }
+
     public function test_merge_wheres_can_merge_wheres_and_bindings()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -376,6 +376,25 @@ class Oci8SchemaGrammarTest extends TestCase
         );
     }
 
+    public function test_basic_create_table_with_not_valid_foreign_key()
+    {
+        $conn = $this->getConnection(prefix: 'prefix_');
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->integer('id')->primary();
+        $blueprint->string('email');
+        $blueprint->integer('foo_id');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->notValid();
+        $blueprint->create();
+
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, "FOO_ID" number(10,0) not null, constraint prefix_users_foo_id_fk foreign key ( "FOO_ID" ) references "PREFIX_ORDERS" ( "ID" ) enable novalidate, constraint prefix_users_id_pk primary key ( "ID" ) )',
+            $statements[0]
+        );
+    }
+
     public function test_basic_alter_table()
     {
         $conn = $this->getConnection();
@@ -1066,6 +1085,20 @@ class Oci8SchemaGrammarTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertEquals(
             'alter table "USERS" add constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "ORDERS" ( "ID" ) deferrable initially deferred',
+            $statements[0]
+        );
+    }
+
+    public function test_adding_not_valid_foreign_key()
+    {
+        $conn = $this->getConnection();
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->notValid();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter table "USERS" add constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "ORDERS" ( "ID" ) enable novalidate',
             $statements[0]
         );
     }

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -35,6 +35,25 @@ class Oci8SchemaGrammarTest extends TestCase
         );
     }
 
+    public function test_basic_create_temporary_table()
+    {
+        $conn = $this->getConnection();
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->create();
+
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'create global temporary table "USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, constraint users_id_pk primary key ( "ID" ) ) on commit preserve rows',
+            $statements[0]
+        );
+    }
+
     public function test_create_table_with_comments()
     {
         $conn = $this->getConnection();

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -357,6 +357,25 @@ class Oci8SchemaGrammarTest extends TestCase
         );
     }
 
+    public function test_basic_create_table_with_deferrable_foreign_key()
+    {
+        $conn = $this->getConnection(prefix: 'prefix_');
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->integer('id')->primary();
+        $blueprint->string('email');
+        $blueprint->integer('foo_id');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->deferrable()->initiallyImmediate(false);
+        $blueprint->create();
+
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'create table "PREFIX_USERS" ( "ID" number(10,0) not null, "EMAIL" varchar2(255) not null, "FOO_ID" number(10,0) not null, constraint prefix_users_foo_id_fk foreign key ( "FOO_ID" ) references "PREFIX_ORDERS" ( "ID" ) deferrable initially deferred, constraint prefix_users_id_pk primary key ( "ID" ) )',
+            $statements[0]
+        );
+    }
+
     public function test_basic_alter_table()
     {
         $conn = $this->getConnection();
@@ -952,6 +971,17 @@ class Oci8SchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "USERS" add constraint bar unique ( "FOO" )', $statements[0]);
     }
 
+    public function test_adding_deferrable_unique_key()
+    {
+        $conn = $this->getConnection();
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->unique('foo', 'bar')->deferrable()->initiallyImmediate(false);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "USERS" add constraint bar unique ( "FOO" ) deferrable initially deferred', $statements[0]);
+    }
+
     public function test_adding_defined_unique_key_with_prefix()
     {
         $conn = $this->getConnection(prefix: 'prefix_');
@@ -1024,6 +1054,20 @@ class Oci8SchemaGrammarTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "USERS" add constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "ORDERS" ( "ID" )',
             $statements[0]);
+    }
+
+    public function test_adding_deferrable_foreign_key()
+    {
+        $conn = $this->getConnection();
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->deferrable()->initiallyImmediate(false);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter table "USERS" add constraint users_foo_id_fk foreign key ( "FOO_ID" ) references "ORDERS" ( "ID" ) deferrable initially deferred',
+            $statements[0]
+        );
     }
 
     public function test_adding_foreign_key_with_cascade_delete()

--- a/tests/Database/Oci8SchemaGrammarTest.php
+++ b/tests/Database/Oci8SchemaGrammarTest.php
@@ -1037,6 +1037,17 @@ class Oci8SchemaGrammarTest extends TestCase
         $this->assertEquals('create index baz on "USERS" ( "FOO", "BAR" )', $statements[0]);
     }
 
+    public function test_adding_online_index()
+    {
+        $conn = $this->getConnection();
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->index(['foo', 'bar'], 'baz')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create index baz on "USERS" ( "FOO", "BAR" ) online', $statements[0]);
+    }
+
     public function test_adding_m_single_column_full_text_index()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Functional/Compatibility/SchemaTest.php
+++ b/tests/Functional/Compatibility/SchemaTest.php
@@ -18,10 +18,12 @@ class SchemaTest extends TestCase
             DB::statement('begin execute immediate \'drop view "COMPATIBILITY_VIEW"\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop type "COMPATIBILITY_TYPE_LIST" force\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop type "COMPATIBILITY_TYPE" force\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_TEMP_TABLE"\'; exception when others then null; end;');
         } elseif ($driver === 'pgsql') {
             DB::statement('drop view if exists "compatibility_view"');
             DB::statement('drop type if exists compatibility_type_list');
             DB::statement('drop type if exists "compatibility_type"');
+            DB::statement('drop table if exists "compatibility_temp_table"');
         }
 
         if (Schema::hasTable('rename_index_table')) {
@@ -107,6 +109,27 @@ class SchemaTest extends TestCase
         $this->assertArrayHasKey('category', $type);
         $this->assertArrayHasKey('implicit', $type);
         $this->assertFalse((bool) $type['implicit']);
+    }
+
+    #[Test]
+    public function it_can_create_temporary_tables_from_schema_builder()
+    {
+        if (! in_array(DB::connection()->getDriverName(), ['oracle', 'pgsql'], true)) {
+            $this->markTestSkipped('This compatibility test only targets Oracle and PostgreSQL.');
+        }
+
+        Schema::create('compatibility_temp_table', function (Blueprint $table) {
+            $table->temporary();
+            $table->integer('id');
+            $table->string('name');
+        });
+
+        DB::table('compatibility_temp_table')->insert([
+            'id' => 1,
+            'name' => 'temporary',
+        ]);
+
+        $this->assertSame('temporary', DB::table('compatibility_temp_table')->value('name'));
     }
 
     #[Test]

--- a/tests/Functional/Compatibility/SchemaTest.php
+++ b/tests/Functional/Compatibility/SchemaTest.php
@@ -19,11 +19,17 @@ class SchemaTest extends TestCase
             DB::statement('begin execute immediate \'drop type "COMPATIBILITY_TYPE_LIST" force\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop type "COMPATIBILITY_TYPE" force\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_TEMP_TABLE"\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_POSTS"\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_USERS"\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_MAIL"\'; exception when others then null; end;');
         } elseif ($driver === 'pgsql') {
             DB::statement('drop view if exists "compatibility_view"');
             DB::statement('drop type if exists compatibility_type_list');
             DB::statement('drop type if exists "compatibility_type"');
             DB::statement('drop table if exists "compatibility_temp_table"');
+            DB::statement('drop table if exists "compatibility_deferrable_posts"');
+            DB::statement('drop table if exists "compatibility_deferrable_users"');
+            DB::statement('drop table if exists "compatibility_deferrable_mail"');
         }
 
         if (Schema::hasTable('rename_index_table')) {
@@ -130,6 +136,74 @@ class SchemaTest extends TestCase
         ]);
 
         $this->assertSame('temporary', DB::table('compatibility_temp_table')->value('name'));
+    }
+
+    #[Test]
+    public function it_can_use_deferrable_constraints_from_schema_builder()
+    {
+        if (! in_array(DB::connection()->getDriverName(), ['oracle', 'pgsql'], true)) {
+            $this->markTestSkipped('This compatibility test only targets Oracle and PostgreSQL.');
+        }
+
+        Schema::create('compatibility_deferrable_users', function (Blueprint $table) {
+            $table->integer('id')->primary();
+        });
+
+        Schema::create('compatibility_deferrable_posts', function (Blueprint $table) {
+            $table->integer('id')->primary();
+            $table->integer('user_id');
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('compatibility_deferrable_users')
+                ->deferrable()
+                ->initiallyImmediate(false);
+        });
+
+        Schema::create('compatibility_deferrable_mail', function (Blueprint $table) {
+            $table->integer('id')->primary();
+            $table->string('email');
+            $table->unique('email')
+                ->deferrable()
+                ->initiallyImmediate(false);
+        });
+
+        DB::transaction(function () {
+            DB::table('compatibility_deferrable_posts')->insert([
+                'id' => 10,
+                'user_id' => 1,
+            ]);
+
+            DB::table('compatibility_deferrable_users')->insert([
+                'id' => 1,
+            ]);
+        });
+
+        $this->assertSame(1, DB::table('compatibility_deferrable_posts')->where('user_id', 1)->count());
+
+        DB::table('compatibility_deferrable_mail')->insert([
+            ['id' => 1, 'email' => 'alpha@example.test'],
+            ['id' => 2, 'email' => 'beta@example.test'],
+        ]);
+
+        DB::transaction(function () {
+            DB::table('compatibility_deferrable_mail')
+                ->where('id', 1)
+                ->update(['email' => 'beta@example.test']);
+
+            DB::table('compatibility_deferrable_mail')
+                ->where('id', 2)
+                ->update(['email' => 'alpha@example.test']);
+        });
+
+        $emails = DB::table('compatibility_deferrable_mail')
+            ->orderBy('id')
+            ->pluck('email')
+            ->all();
+
+        $this->assertSame([
+            'beta@example.test',
+            'alpha@example.test',
+        ], $emails);
     }
 
     #[Test]

--- a/tests/Functional/Compatibility/SchemaTest.php
+++ b/tests/Functional/Compatibility/SchemaTest.php
@@ -24,6 +24,7 @@ class SchemaTest extends TestCase
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_MAIL"\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_NOT_VALID_POSTS"\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_NOT_VALID_USERS"\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_ONLINE_INDEXES"\'; exception when others then null; end;');
         } elseif ($driver === 'pgsql') {
             DB::statement('drop view if exists "compatibility_view"');
             DB::statement('drop type if exists compatibility_type_list');
@@ -34,6 +35,7 @@ class SchemaTest extends TestCase
             DB::statement('drop table if exists "compatibility_deferrable_mail"');
             DB::statement('drop table if exists "compatibility_not_valid_posts"');
             DB::statement('drop table if exists "compatibility_not_valid_users"');
+            DB::statement('drop table if exists "compatibility_online_indexes"');
         }
 
         if (Schema::hasTable('rename_index_table')) {
@@ -259,6 +261,34 @@ class SchemaTest extends TestCase
         } catch (\Illuminate\Database\QueryException $e) {
             $this->assertTrue(true);
         }
+    }
+
+    #[Test]
+    public function it_can_create_online_indexes_from_schema_builder()
+    {
+        if (! $this->isPgsql() && ! $this->isMariaDb() && version_compare($this->serverVersion(), '12c', '<')) {
+            $this->markTestSkipped('Online index builds are not enabled on Oracle 11g.');
+        }
+
+        if (! in_array(DB::connection()->getDriverName(), ['oracle', 'pgsql'], true)) {
+            $this->markTestSkipped('This compatibility test only targets Oracle and PostgreSQL.');
+        }
+
+        Schema::create('compatibility_online_indexes', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('name');
+        });
+
+        Schema::table('compatibility_online_indexes', function (Blueprint $table) {
+            $table->index('name', 'compat_online_name')->online();
+        });
+
+        $indexes = collect(Schema::getIndexes('compatibility_online_indexes'))
+            ->pluck('name')
+            ->map(fn ($name) => strtolower($name))
+            ->all();
+
+        $this->assertContains('compat_online_name', $indexes);
     }
 
     #[Test]

--- a/tests/Functional/Compatibility/SchemaTest.php
+++ b/tests/Functional/Compatibility/SchemaTest.php
@@ -22,6 +22,8 @@ class SchemaTest extends TestCase
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_POSTS"\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_USERS"\'; exception when others then null; end;');
             DB::statement('begin execute immediate \'drop table "COMPATIBILITY_DEFERRABLE_MAIL"\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_NOT_VALID_POSTS"\'; exception when others then null; end;');
+            DB::statement('begin execute immediate \'drop table "COMPATIBILITY_NOT_VALID_USERS"\'; exception when others then null; end;');
         } elseif ($driver === 'pgsql') {
             DB::statement('drop view if exists "compatibility_view"');
             DB::statement('drop type if exists compatibility_type_list');
@@ -30,6 +32,8 @@ class SchemaTest extends TestCase
             DB::statement('drop table if exists "compatibility_deferrable_posts"');
             DB::statement('drop table if exists "compatibility_deferrable_users"');
             DB::statement('drop table if exists "compatibility_deferrable_mail"');
+            DB::statement('drop table if exists "compatibility_not_valid_posts"');
+            DB::statement('drop table if exists "compatibility_not_valid_users"');
         }
 
         if (Schema::hasTable('rename_index_table')) {
@@ -204,6 +208,57 @@ class SchemaTest extends TestCase
             'beta@example.test',
             'alpha@example.test',
         ], $emails);
+    }
+
+    #[Test]
+    public function it_can_use_not_valid_foreign_keys_from_schema_builder()
+    {
+        if (! in_array(DB::connection()->getDriverName(), ['oracle', 'pgsql'], true)) {
+            $this->markTestSkipped('This compatibility test only targets Oracle and PostgreSQL.');
+        }
+
+        Schema::create('compatibility_not_valid_users', function (Blueprint $table) {
+            $table->integer('id')->primary();
+        });
+
+        Schema::create('compatibility_not_valid_posts', function (Blueprint $table) {
+            $table->integer('id')->primary();
+            $table->integer('user_id');
+        });
+
+        DB::table('compatibility_not_valid_posts')->insert([
+            'id' => 10,
+            'user_id' => 999,
+        ]);
+
+        Schema::table('compatibility_not_valid_posts', function (Blueprint $table) {
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('compatibility_not_valid_users')
+                ->notValid();
+        });
+
+        DB::table('compatibility_not_valid_users')->insert([
+            'id' => 1,
+        ]);
+
+        DB::table('compatibility_not_valid_posts')->insert([
+            'id' => 11,
+            'user_id' => 1,
+        ]);
+
+        $this->assertSame(2, DB::table('compatibility_not_valid_posts')->count());
+
+        try {
+            DB::table('compatibility_not_valid_posts')->insert([
+                'id' => 12,
+                'user_id' => 5000,
+            ]);
+
+            $this->fail('Expected the not valid foreign key to reject new invalid rows.');
+        } catch (\Illuminate\Database\QueryException $e) {
+            $this->assertTrue(true);
+        }
     }
 
     #[Test]

--- a/tests/Functional/Compatibility/TruncateCascadeTest.php
+++ b/tests/Functional/Compatibility/TruncateCascadeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional\Compatibility;
+
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\Oci8\Query\Grammars\OracleGrammar;
+use Yajra\Oci8\Tests\TestCase;
+
+class TruncateCascadeTest extends TestCase
+{
+    protected bool $createdSchema = false;
+
+    protected function tearDown(): void
+    {
+        OracleGrammar::cascadeOnTruncate(false);
+        PostgresGrammar::cascadeOnTruncate();
+
+        if ($this->createdSchema) {
+            Schema::dropIfExists('compatibility_truncate_child');
+            Schema::dropIfExists('compatibility_truncate_parent');
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_can_truncate_with_cascade_enabled()
+    {
+        if (! in_array(DB::connection()->getDriverName(), ['oracle', 'pgsql'], true)) {
+            $this->markTestSkipped('This compatibility test only targets Oracle and PostgreSQL.');
+        }
+
+        if (DB::connection()->getDriverName() === 'oracle' && DB::connection()->isVersionBelow('12c')) {
+            $this->markTestSkipped('TRUNCATE CASCADE is only supported by Oracle 12c and newer.');
+        }
+
+        $this->createdSchema = true;
+
+        Schema::create('compatibility_truncate_parent', function (Blueprint $table) {
+            $table->integer('id')->primary();
+        });
+
+        Schema::create('compatibility_truncate_child', function (Blueprint $table) {
+            $table->integer('id')->primary();
+            $table->integer('parent_id');
+            $table->foreign('parent_id')
+                ->references('id')
+                ->on('compatibility_truncate_parent')
+                ->cascadeOnDelete();
+        });
+
+        DB::table('compatibility_truncate_parent')->insert(['id' => 1]);
+        DB::table('compatibility_truncate_child')->insert(['id' => 1, 'parent_id' => 1]);
+
+        if (DB::connection()->getDriverName() === 'oracle') {
+            OracleGrammar::cascadeOnTruncate();
+        } else {
+            PostgresGrammar::cascadeOnTruncate();
+        }
+
+        DB::table('compatibility_truncate_parent')->truncate();
+
+        $this->assertSame(0, DB::table('compatibility_truncate_parent')->count());
+        $this->assertSame(0, DB::table('compatibility_truncate_child')->count());
+    }
+}


### PR DESCRIPTION
Miscellaneous schema builder functions:
- Add support for temporary tables:
Laravel docs: https://laravel.com/docs/13.x/migrations#database-connection-table-options
- Add support for deferrable and initiallyImmediate on indexes and foreign keys
- add support for notValid in schema builder
- add support for online mode for indexes
- add support for cascadeOnTruncate

Thank you for reviewing!