### PR TITLE
fix: limit index length to 30 to prevent errors on oracle 11g and below

### DIFF
--- a/src/Oci8/Schema/OracleBlueprint.php
+++ b/src/Oci8/Schema/OracleBlueprint.php
@@ -70,7 +70,7 @@ class OracleBlueprint extends Blueprint
                 $index = implode('_', $parts);
             }
         } else {
-            $index = mb_substr($this->table, 0, 10).'_comp_'.str_replace('.', '_', microtime(true));
+            $index = mb_substr($this->table, 0, 9).'_comp_'.str_replace('.', '_', microtime(true));
         }
 
         return $index;


### PR DESCRIPTION
Limit index name to 30 char.

Bug trigger introduced in: https://github.com/laravel/laravel/commit/a29735c8a1d2e9026da8b25a74e662864829f506.

Results in:
 (Connection: oracle, Host: , Port: 1521, Database: , SQL: create index failed_job_comp_1778724292_7786 on "FAILED_JOBS" ( "CONNECTION", "QUEUE", "FAILED_AT" ))
 
Should fix ci errors in: [Fresh Laravel Install](https://github.com/yajra/laravel-oci8/actions/workflows/fresh-laravel-install-test.yml).

Thank you for reviewing!


