### PR TITLE
Update OracleGrammar.php with case sensitive modifications

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -42,6 +42,11 @@ class OracleGrammar extends Grammar
     protected $labelSearchFullText = 1;
 
     /**
+     * @var bool
+     */
+    protected $caseSensitive;
+
+    /**
      * Compile a delete statement with joins into SQL.
      *
      * @param  string  $table
@@ -74,6 +79,14 @@ class OracleGrammar extends Grammar
      */
     public function compileSelect(Builder $query): string
     {
+            if ($query->getConnection()->getConfig('options') != null){
+            if ($query->getConnection()->getConfig('options')['8'] === 0){
+                $this->caseSensitive = true;
+            }
+        } else {
+            $this->caseSensitive = false;
+        }
+        
         if (($query->unions || $query->havings) && $query->aggregate) {
             return $this->compileUnionAggregate($query);
         }
@@ -347,7 +360,9 @@ class OracleGrammar extends Grammar
             return $value;
         }
 
-        $value = Str::upper($value);
+        if ($this->caseSensitive != true) {
+            $value = Str::upper($value);
+        }
 
         return '"'.str_replace('"', '""', $value).'"';
     }


### PR DESCRIPTION
- Added PDO::ATTR_CASE => PDO::CASE_NATURAL configuration 'oracle' => [ 'driver' => 'oracle', 'options' => array( PDO::ATTR_CASE => PDO::CASE_NATURAL, ), ],
- Preserves case sensitivity in Oracle query results
- Compatible with Laravel 13.x and Oracle 11g

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
