### PR TITLE
ci: update ci workflow to use actions/download-artifact@v8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -387,7 +387,7 @@ jobs:
           ./phpcov --version
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-oracle-*
           path: build/coverage


### PR DESCRIPTION
Update ci workflow to use v8 for actions/download-artifact.

Thank you for reviewing!