### PR TITLE
fix: strip qualifiers from Oracle update columns

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -611,11 +611,13 @@ class OracleGrammar extends Grammar
     protected function compileUpdateColumns(Builder $query, array $values): string
     {
         return collect($values)->map(function ($value, $key) use ($query) {
-            if ($this->isJsonSelector($key)) {
-                return $this->compileJsonUpdateColumn($query, $key, $value);
+            $column = last(explode('.', $key));
+
+            if ($this->isJsonSelector($column)) {
+                return $this->compileJsonUpdateColumn($query, $column, $value);
             }
 
-            return $this->wrap($key).' = '.$this->parameter($value);
+            return $this->wrap($column).' = '.$this->parameter($value);
         })->implode(', ');
     }
 

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -2736,6 +2736,22 @@ class Oci8QueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function test_update_method_strips_column_qualifiers()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()
+            ->shouldReceive('update')
+            ->once()
+            ->with('update "USERS" set "EMAIL" = ?, "NAME" = ? where "USERS"."ID" = ?', ['foo', 'bar', 1])
+            ->andReturn(1);
+
+        $result = $builder->from('users')
+            ->where('users.id', '=', 1)
+            ->update(['users.email' => 'foo', 'users.name' => 'bar']);
+
+        $this->assertEquals(1, $result);
+    }
+
     public function test_update_method_with_json_selector()
     {
         $connection = $this->getConnection(serverVersion: '19c');
@@ -2748,6 +2764,24 @@ class Oci8QueryBuilderTest extends TestCase
             ->andReturn(1);
 
         $result = $builder->from('users')->where('id', '=', 1)->update(['options->language' => 'en']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function test_update_method_with_qualified_json_selector()
+    {
+        $connection = $this->getConnection(serverVersion: '19c');
+        $builder = new Builder($connection, new OracleGrammar($connection), m::mock(OracleProcessor::class));
+
+        $builder->getConnection()
+            ->shouldReceive('update')
+            ->once()
+            ->with('update "USERS" set "OPTIONS" = json_transform("OPTIONS", SET \'$."language"\' = ?) where "USERS"."ID" = ?', ['en', 1])
+            ->andReturn(1);
+
+        $result = $builder->from('users')
+            ->where('users.id', '=', 1)
+            ->update(['users.options->language' => 'en']);
+
         $this->assertEquals(1, $result);
     }
 

--- a/tests/Functional/Compatibility/QualifiedUpdateTest.php
+++ b/tests/Functional/Compatibility/QualifiedUpdateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional\Compatibility;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\Oci8\Tests\TestCase;
+
+class QualifiedUpdateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('qualified_update_users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->json('options')->nullable();
+        });
+
+        DB::table('qualified_update_users')->insert([
+            'name' => 'Alice',
+            'options' => json_encode(['language' => 'en']),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('qualified_update_users');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_updates_a_qualified_column(): void
+    {
+        $updated = DB::table('qualified_update_users')
+            ->where('qualified_update_users.id', '=', 1)
+            ->update(['qualified_update_users.name' => 'Updated']);
+
+        $this->assertSame(1, $updated);
+        $this->assertSame('Updated', DB::table('qualified_update_users')->value('name'));
+    }
+
+    #[Test]
+    public function it_updates_a_qualified_json_selector(): void
+    {
+        $connection = DB::connection();
+
+        if ($connection->getDriverName() === 'oracle' && $connection->isVersionBelow('19c')) {
+            $this->markTestSkipped('Oracle JSON path updates require Oracle 19c or newer.');
+        }
+
+        $updated = DB::table('qualified_update_users')
+            ->where('qualified_update_users.id', '=', 1)
+            ->update(['qualified_update_users.options->language' => 'de']);
+
+        $this->assertSame(1, $updated);
+        $this->assertSame(
+            'de',
+            DB::table('qualified_update_users')
+                ->where('id', '=', 1)
+                ->value('options->language')
+        );
+    }
+}


### PR DESCRIPTION
Strip qualifiers from columns in update queries to match pgsql behavior.

Thank you for reviewing!