### PR TITLE
feat: implement whereNullSafeEquals

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -769,6 +769,19 @@ class OracleGrammar extends Grammar
     }
 
     /**
+     * Compile a "where null safe equals" clause.
+     *
+     * Oracle's DECODE treats two NULL values as equal, matching Laravel's
+     * null-safe equality semantics without requiring duplicate bindings.
+     *
+     * @param  array  $where
+     */
+    protected function whereNullSafeEquals(Builder $query, $where): string
+    {
+        return 'DECODE('.$this->wrap($where['column']).', '.$this->parameter($where['value']).', 1, 0) = 1';
+    }
+
+    /**
      * Compile a "where not in raw" clause.
      *
      * For safety, whereIntegerInRaw ensures this method is only used with integer values.

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -326,6 +326,27 @@ class Oci8QueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function test_where_null_safe_equals()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNullSafeEquals('id', 1);
+        $this->assertSame('select * from "USERS" where DECODE("ID", ?, 1, 0) = 1', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNullSafeEquals('id', null);
+        $this->assertSame('select * from "USERS" where DECODE("ID", ?, 1, 0) = 1', $builder->toSql());
+        $this->assertEquals([0 => null], $builder->getBindings());
+    }
+
+    public function test_where_null_safe_equals_operator()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '<=>', 1);
+        $this->assertSame('select * from "USERS" where DECODE("ID", ?, 1, 0) = 1', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function test_wheres_with_array_value()
     {
         $builder = $this->getBuilder();

--- a/tests/Functional/Compatibility/NullSafeEqualsTest.php
+++ b/tests/Functional/Compatibility/NullSafeEqualsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional\Compatibility;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\Oci8\Tests\TestCase;
+
+class NullSafeEqualsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('compatibility_nullsafe_items', function (Blueprint $table) {
+            $table->integer('id')->primary();
+            $table->string('category')->nullable();
+        });
+
+        DB::table('compatibility_nullsafe_items')->insert([
+            ['id' => 1, 'category' => null],
+            ['id' => 2, 'category' => 'news'],
+            ['id' => 3, 'category' => 'news'],
+            ['id' => 4, 'category' => 'blog'],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('compatibility_nullsafe_items');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_matches_null_values()
+    {
+        $ids = DB::table('compatibility_nullsafe_items')
+            ->whereNullSafeEquals('category', null)
+            ->orderBy('id')
+            ->get(['id'])
+            ->pluck('id')
+            ->map(static fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertSame([1], $ids);
+    }
+
+    #[Test]
+    public function it_matches_non_null_values()
+    {
+        $ids = DB::table('compatibility_nullsafe_items')
+            ->whereNullSafeEquals('category', 'news')
+            ->orderBy('id')
+            ->get(['id'])
+            ->pluck('id')
+            ->map(static fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertSame([2, 3], $ids);
+    }
+
+    #[Test]
+    public function it_matches_non_null_values_through_the_operator()
+    {
+        $ids = DB::table('compatibility_nullsafe_items')
+            ->where('category', '<=>', 'blog')
+            ->orderBy('id')
+            ->get(['id'])
+            ->pluck('id')
+            ->map(static fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertSame([4], $ids);
+    }
+
+    #[Test]
+    public function it_can_be_negated()
+    {
+        $ids = DB::table('compatibility_nullsafe_items')
+            ->whereNot(fn ($query) => $query->whereNullSafeEquals('category', 'news'))
+            ->orderBy('id')
+            ->get(['id'])
+            ->pluck('id')
+            ->map(static fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertSame([1, 4], $ids);
+    }
+}


### PR DESCRIPTION
Implement missing whereNullSafeEquals.

It seems to be used in whereNotMorphedTo method in laravel framework. 

Thank you for reviewing!