### PR TITLE
fix: include all changes in release notes

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           semantic_version: 25.0.6
           extra_plugins: |
+            @semantic-release/changelog@6.0.3
+            @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@10.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -17,18 +17,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           persist-credentials: false
-
-      - name: Setup Configuration
-        run: |
-          if [ -n "$GH_TOKEN_SECRET" ]; then
-            echo "GH_TOKEN=$GH_TOKEN_SECRET" >> $GITHUB_ENV
-          else
-            echo "GH_TOKEN=$GITHUB_TOKEN" >> $GITHUB_ENV
-          fi
-        env:
-          GH_TOKEN_SECRET: ${{ secrets.GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -37,5 +27,9 @@ jobs:
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16
+        with:
+          semantic_version: 25.0.6
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@10.2.1
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -6,7 +6,27 @@
     ],
     "plugins": [
         "@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits",
+                "presetConfig": {
+                    "types": [
+                        { "type": "feat", "section": "Features", "effect": "bump" },
+                        { "type": "fix", "section": "Bug Fixes", "effect": "bump" },
+                        { "type": "perf", "section": "Performance Improvements", "effect": "bump" },
+                        { "type": "refactor", "section": "Code Refactoring", "effect": "changelog" },
+                        { "type": "test", "section": "Tests", "effect": "changelog" },
+                        { "type": "build", "section": "Build System", "effect": "changelog" },
+                        { "type": "ci", "section": "Continuous Integration", "effect": "changelog" },
+                        { "type": "docs", "section": "Documentation", "effect": "changelog" },
+                        { "type": "style", "section": "Styles", "effect": "changelog" },
+                        { "type": "chore", "section": "Chores", "effect": "changelog" },
+                        { "type": "revert", "section": "Reverts", "effect": "bump" }
+                    ]
+                }
+            }
+        ],
         [
             "@semantic-release/changelog",
             {


### PR DESCRIPTION
## Summary

- generate release notes for every configured Conventional Commit category, including refactors and tests
- preserve semantic version triggering for features, fixes, performance changes, and reverts
- fetch complete Git history and tags before semantic-release runs
- fix the GitHub token fallback and pin semantic-release dependencies

## Root cause

The release-notes generator hid non-release-driving commit categories by default. As a result, v13.8.0 listed the feature commit but omitted the refactor and test changes merged in the same release range. The workflow also computed a fallback token and then overwrote it with the optional secret.

## Impact

Future releases will retain semantic version behavior while documenting all conventional change categories included in the release.

## Verification

- `jq empty .releaserc.yml`
- GitHub workflow YAML parsing
- `git diff --check`
- `vendor/bin/pint --test`
- `vendor/bin/phpstan analyse --memory-limit=2G --ansi --no-progress --no-interaction --configuration=phpstan.neon.dist`

## Baseline check limitations

- Rector dry-run reports 22 unrelated existing files that would be changed.
- The local PHPUnit run reports existing dependency/mock expectation failures and Oracle-environment errors; the repository CI matrix remains the authoritative test environment.