### PR TITLE
fix: compile joined updates for Oracle

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -705,6 +705,32 @@ class OracleGrammar extends Grammar
     }
 
     /**
+     * Compile an update statement into SQL.
+     */
+    public function compileUpdate(Builder $query, array $values): string
+    {
+        if (isset($query->joins)) {
+            return $this->compileUpdateWithJoinsUsingRowId($query, $values);
+        }
+
+        return parent::compileUpdate($query, $values);
+    }
+
+    /**
+     * Compile an update with joins using an Oracle ROWID subquery.
+     */
+    protected function compileUpdateWithJoinsUsingRowId(Builder $query, array $values): string
+    {
+        $table = $this->wrapTable($query->from);
+        $columns = $this->compileUpdateColumns($query, $values);
+        $target = $this->getUpdateFromTargetReference($query);
+        $selectQuery = clone $query;
+        $select = $this->compileSelect($selectQuery->select($target.'.rowid'));
+
+        return "update {$table} set {$columns} where {$this->wrap('rowid')} in ({$select})";
+    }
+
+    /**
      * Compile the columns for an update statement.
      */
     protected function compileUpdateColumns(Builder $query, array $values): string
@@ -748,7 +774,10 @@ class OracleGrammar extends Grammar
                 : $value)
             ->all();
 
-        return parent::prepareBindingsForUpdate($bindings, $values);
+        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
+        $cleanBindings = Arr::except($bindings, 'select');
+
+        return array_values(array_merge($values, Arr::flatten($cleanBindings)));
     }
 
     /**

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -3073,13 +3073,55 @@ class Oci8QueryBuilderTest extends TestCase
         $builder->getConnection()
             ->shouldReceive('update')
             ->once()
-            ->with('update "USERS" inner join "ORDERS" on "USERS"."ID" = "ORDERS"."USER_ID" set "EMAIL" = ?, "NAME" = ? where "USERS"."ID" = ?',
+            ->with('update "USERS" set "EMAIL" = ?, "NAME" = ? where "ROWID" in (select "USERS"."ROWID" from "USERS" inner join "ORDERS" on "USERS"."ID" = "ORDERS"."USER_ID" where "USERS"."ID" = ?)',
                 ['foo', 'bar', 1])
             ->andReturn(1);
         $result = $builder->from('users')
             ->join('orders', 'users.id', '=', 'orders.user_id')
             ->where('users.id', '=', 1)
             ->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function test_update_method_with_join_bindings()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()
+            ->shouldReceive('update')
+            ->once()
+            ->with(
+                'update "USERS" set "ACTIVE" = ? where "ROWID" in (select "USERS"."ROWID" from "USERS" inner join "PROFILES" on "USERS"."ID" = "PROFILES"."USER_ID" and "PROFILES"."TYPE" = ? where "USERS"."ID" = ?)',
+                [true, 'admin', 1]
+            )
+            ->andReturn(1);
+
+        $result = $builder->from('users')
+            ->join('profiles', function ($join) {
+                $join->on('users.id', '=', 'profiles.user_id')
+                    ->where('profiles.type', '=', 'admin');
+            })
+            ->where('users.id', '=', 1)
+            ->update(['active' => true]);
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function test_update_method_with_join_uses_prefixed_alias_rowid()
+    {
+        $builder = $this->getBuilder('prefix_');
+        $builder->getConnection()
+            ->shouldReceive('update')
+            ->once()
+            ->with(
+                'update "PREFIX_USERS" "PREFIX_U" set "ACTIVE" = ? where "ROWID" in (select "PREFIX_U"."ROWID" from "PREFIX_USERS" "PREFIX_U" inner join "PREFIX_PROFILES" "PREFIX_P" on "PREFIX_U"."ID" = "PREFIX_P"."USER_ID")',
+                [true]
+            )
+            ->andReturn(1);
+
+        $result = $builder->from('users as u')
+            ->join('profiles as p', 'u.id', '=', 'p.user_id')
+            ->update(['active' => true]);
+
         $this->assertEquals(1, $result);
     }
 

--- a/tests/Functional/Compatibility/JoinedUpdateTest.php
+++ b/tests/Functional/Compatibility/JoinedUpdateTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Yajra\Oci8\Tests\Functional\Compatibility;
+
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\Oci8\Tests\TestCase;
+
+class JoinedUpdateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('joined_update_users', function (Blueprint $table) {
+            $table->id();
+            $table->string('status');
+        });
+
+        Schema::create('joined_update_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('type');
+        });
+
+        DB::table('joined_update_users')->insert([
+            ['id' => 1, 'status' => 'pending'],
+            ['id' => 2, 'status' => 'pending'],
+            ['id' => 3, 'status' => 'inactive'],
+            ['id' => 4, 'status' => 'pending'],
+        ]);
+
+        DB::table('joined_update_profiles')->insert([
+            ['user_id' => 1, 'type' => 'admin'],
+            ['user_id' => 2, 'type' => 'member'],
+            ['user_id' => 3, 'type' => 'admin'],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('joined_update_profiles');
+        Schema::dropIfExists('joined_update_users');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_updates_rows_matching_a_join(): void
+    {
+        $updated = DB::table('joined_update_users as u')
+            ->join('joined_update_profiles as p', function (JoinClause $join) {
+                $join->on('u.id', '=', 'p.user_id')
+                    ->where('p.type', '=', 'admin');
+            })
+            ->where('u.status', '=', 'pending')
+            ->update(['status' => 'active']);
+
+        $this->assertSame(1, $updated);
+        $this->assertDatabaseHas('joined_update_users', ['id' => 1, 'status' => 'active']);
+        $this->assertDatabaseHas('joined_update_users', ['id' => 2, 'status' => 'pending']);
+        $this->assertDatabaseHas('joined_update_users', ['id' => 3, 'status' => 'inactive']);
+    }
+
+    #[Test]
+    public function it_preserves_left_join_semantics(): void
+    {
+        $updated = DB::table('joined_update_users as u')
+            ->leftJoin('joined_update_profiles as p', 'u.id', '=', 'p.user_id')
+            ->whereNull('p.user_id')
+            ->update(['status' => 'orphaned']);
+
+        $this->assertSame(1, $updated);
+        $this->assertDatabaseHas('joined_update_users', ['id' => 4, 'status' => 'orphaned']);
+        $this->assertDatabaseMissing('joined_update_users', ['id' => 1, 'status' => 'orphaned']);
+        $this->assertDatabaseMissing('joined_update_users', ['id' => 2, 'status' => 'orphaned']);
+        $this->assertDatabaseMissing('joined_update_users', ['id' => 3, 'status' => 'orphaned']);
+    }
+}


### PR DESCRIPTION
Oracle does not support joined updates using Laravel’s default SQL syntax. This PR compiles updates with joins using a ROWID subquery instead.

Thank you for reviewing!