### PR TITLE
fix: remove unnecessary wrapping of column alias in OracleGrammar

### DIFF
--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -373,8 +373,8 @@ class OracleGrammar extends Grammar
                 return 't2.*';
             }
 
-            if (preg_match('/\s+as\s+(.+)$/i', $value, $matches)) {
-                $columns[] = 't2.'.$matches[1];
+            if (preg_match('/\s+as\s+"?([^"]+)"?$/i', $value, $matches)) {
+                $columns[] = 't2.'.$this->wrap($matches[1]);
 
                 continue;
             }

--- a/src/Oci8/Query/Grammars/OracleGrammar.php
+++ b/src/Oci8/Query/Grammars/OracleGrammar.php
@@ -374,7 +374,7 @@ class OracleGrammar extends Grammar
             }
 
             if (preg_match('/\s+as\s+(.+)$/i', $value, $matches)) {
-                $columns[] = 't2.'.$this->wrap($matches[1]);
+                $columns[] = 't2.'.$matches[1];
 
                 continue;
             }

--- a/tests/Database/Oci8QueryBuilderTest.php
+++ b/tests/Database/Oci8QueryBuilderTest.php
@@ -1709,6 +1709,21 @@ class Oci8QueryBuilderTest extends TestCase
         }
     }
 
+    public function test_limit_and_offset_does_not_double_wrap_quoted_alias()
+    {
+        $builder = $this->getBuilder(serverVersion: '11g');
+        $builder->from('article')
+            ->select('id')
+            ->selectRaw('(select sum("STOCK"."QUANTITY") from "STOCK" where "ARTICLE"."ID" = "STOCK"."_ARTICLE_ID") as "STOCKS_SUM_QUANTITY"')
+            ->offset(0)
+            ->limit(10);
+
+        $this->assertSame(
+            'select t2."ID", t2."STOCKS_SUM_QUANTITY" from ( select rownum AS "rn", t1.* from (select "ID", (select sum("STOCK"."QUANTITY") from "STOCK" where "ARTICLE"."ID" = "STOCK"."_ARTICLE_ID") as "STOCKS_SUM_QUANTITY" from "ARTICLE") t1 ) t2 where t2."rn" between 1 and 10',
+            $builder->toSql()
+        );
+    }
+
     public function test_for_page()
     {
         $builder = $this->getBuilder();

--- a/tests/Functional/Compatibility/WithTest.php
+++ b/tests/Functional/Compatibility/WithTest.php
@@ -167,6 +167,30 @@ class WithTest extends TestCase
             User::withSum('children', 'score')->find($user->id)->children_sum_score
         );
     }
+
+    #[Test]
+    public function it_works_with_sum_when_using_limit_and_offset()
+    {
+        $user = User::create([
+            'name' => 'test',
+            'email' => 'test@test.hu',
+        ]);
+
+        Child::create([
+            'name' => 'child',
+            'user_id' => $user->id,
+            'score' => 50,
+        ]);
+
+        $users = User::select(['id'])
+            ->withSum('children', 'score')
+            ->offset(0)
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(50, $users->first()->children_sum_score);
+    }
 }
 
 /**


### PR DESCRIPTION
Hi @yajra,

This should fix issue **#1035**.

The problem occurs when `withSum()` is used together with selected columns, `offset`, and `limit` on Oracle. In `compileTableExpressionColumns()`, the aggregate alias is already enclosed in double quotes, but it is passed to `wrap()` again. This results in SQL such as:

```sql
t2."""STOCKS_SUM_QUANTITY"""
```

The additional quoting generates invalid Oracle SQL and causes the `ORA-01741` error. This fix prevents the alias from being wrapped more than once.